### PR TITLE
Feature/new api url

### DIFF
--- a/PSAtera/PSAtera.psm1
+++ b/PSAtera/PSAtera.psm1
@@ -34,7 +34,7 @@ function New-AteraGetRequest {
   }
   $ItemsInPage = 50
   $QueryString = Format-QueryString -Query $Query
-  $Uri = "https://app.atera.com/api/v3$($endpoint)?itemsInPage=$ItemsInPage&$QueryString"
+  $Uri = "https://api.atera.com/api/v3$($endpoint)?itemsInPage=$ItemsInPage&$QueryString"
   $items = @()
   $index = 0
 
@@ -76,7 +76,7 @@ function New-AteraPostRequest {
     "content-type" = "application/json"
     "X-API-KEY" = Get-AteraAPIKey
   }
-  $Uri = "https://app.atera.com/api/v3$($endpoint)"
+  $Uri = "https://api.atera.com/api/v3$($endpoint)"
   $JsonBody = ConvertTo-Json -InputObject $Body -Depth 10
   Write-Debug "[PSAtera] Request for $Uri with data $JsonBody"
   $data = Invoke-RestMethod -Uri $Uri -Method "POST" -Headers $Headers -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
@@ -111,7 +111,7 @@ function New-AteraPutRequest {
     "content-type" = "application/json"
     "X-API-KEY" = Get-AteraAPIKey
   }
-  $Uri = "https://app.atera.com/api/v3$($endpoint)"
+  $Uri = "https://api.atera.com/api/v3$($endpoint)"
   Write-Debug "[PSAtera] Request for $Uri"
   $JsonBody = ConvertTo-Json -InputObject $Body -Depth 10
   $data = Invoke-RestMethod -Uri $Uri -Method "Put" -Headers $Headers -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
@@ -125,7 +125,7 @@ $AteraAPIKey = $env:ATERAAPIKEY
   Set the Atera API Key used by the module. If none set, the ATERAAPIKEY environment variable will be used instead.
 
   .Parameter APIKey
-  Atera API Key which can be found at https://app.atera.com/Admin#/admin/api
+  Atera API Key which can be found at https://api.atera.com/Admin#/admin/api
 #>
 function Set-AteraAPIKey {
   param(

--- a/PSAtera/docs.txt
+++ b/PSAtera/docs.txt
@@ -1587,7 +1587,7 @@ DESCRIPTION
 
 PARAMETERS
     -APIKey <String>
-        Atera API Key which can be found at https://app.atera.com/Admin#/admin/api
+        Atera API Key which can be found at https://api.atera.com/Admin#/admin/api
         
     <CommonParameters>
         This cmdlet supports the common parameters: Verbose, Debug,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Start interacting with Atera from PowerShell with the PSAtera module.
 ## Configuration
 
 The PSAtera module relies on the `ATERAAPIKEY` environment variable for the API key for your Atera account which can be found here:
-https://app.atera.com/new/admin/api
+https://api.atera.com/new/admin/api
 
 ## Install
 


### PR DESCRIPTION
Atera has a new API URL: api.atera.com/api/v3
The path of the URL is exactly as before, just the hostname is new. The old URL is still active, but is being gradually phased out.