### PR TITLE
New api key format

### DIFF
--- a/PSAtera/PSAtera.psm1
+++ b/PSAtera/PSAtera.psm1
@@ -111,16 +111,19 @@ function New-AteraPutRequest {
 
 
 $AteraAPIKey = $env:ATERAAPIKEY
+# Legacy static API keys are short; JWT tokens issued by Atera are much longer.
+$script:AteraJwtTokenMinLength = 100
+
 <#
   .Synopsis
-  Set the Atera API token used by the module. If none set, the ATERAAPIKEY environment variable will be used instead.
+  Set the Atera API key or token used by the module. If none set, the ATERAAPIKEY environment variable will be used instead.
 
   .Parameter APIKey
-  Atera JWT token which can be found at https://app.atera.com/new/admin/api
+  Atera API key or JWT token, which can be found at https://app.atera.com/new/admin/api
 #>
 function Set-AteraAPIKey {
   param(
-    # Atera JWT token
+    # Atera API key or JWT token
     [string]$APIKey
   )
   $script:AteraAPIKey = $APIKey
@@ -128,7 +131,7 @@ function Set-AteraAPIKey {
 
 <#
   .Synopsis
-  Get the Atera API token in use by the module.
+  Get the Atera API key or token in use by the module.
 #>
 function Get-AteraAPIKey {
   if (!$AteraAPIKey) { throw "`$AteraAPIKey not set. Set it with either Set-AteraAPIKey or `$env:ATERAAPIKEY" }
@@ -137,13 +140,19 @@ function Get-AteraAPIKey {
 
 <#
   .Synopsis
-  Build request headers for Atera API calls using Bearer JWT authentication.
+  Build request headers for Atera API calls, using Bearer JWT or legacy X-API-KEY authentication.
 #>
 function Get-AteraAuthHeaders {
-  @{
+  $Token = Get-AteraAPIKey
+  $Headers = @{
     "accept" = "application/json"
-    "Authorization" = "Bearer $(Get-AteraAPIKey)"
   }
+  if ($Token.Length -gt $AteraJwtTokenMinLength) {
+    $Headers["Authorization"] = "Bearer $Token"
+  } else {
+    $Headers["X-API-KEY"] = $Token
+  }
+  return $Headers
 }
 
 $RecordLimit = 1000

--- a/PSAtera/PSAtera.psm1
+++ b/PSAtera/PSAtera.psm1
@@ -28,10 +28,7 @@ function New-AteraGetRequest {
     [Parameter()]
     [Hashtable] $Query
   )
-  $Headers = @{
-    "accept" = "application/json"
-    "X-API-KEY" = Get-AteraAPIKey
-  }
+  $Headers = Get-AteraAuthHeaders
   $ItemsInPage = 50
   $QueryString = Format-QueryString -Query $Query
   $Uri = "https://app.atera.com/api/v3$($endpoint)?itemsInPage=$ItemsInPage&$QueryString"
@@ -71,11 +68,8 @@ function New-AteraPostRequest {
     [Parameter(Mandatory, ValueFromPipeline)]
     [Hashtable] $Body
   )
-  $Headers = @{
-    "accept" = "application/json"
-    "content-type" = "application/json"
-    "X-API-KEY" = Get-AteraAPIKey
-  }
+  $Headers = Get-AteraAuthHeaders
+  $Headers["content-type"] = "application/json"
   $Uri = "https://app.atera.com/api/v3$($endpoint)"
   $JsonBody = ConvertTo-Json -InputObject $Body -Depth 10
   Write-Debug "[PSAtera] Request for $Uri with data $JsonBody"
@@ -106,11 +100,8 @@ function New-AteraPutRequest {
     [Parameter(ValueFromPipeline)]
     [Object] $Body
   )
-  $Headers = @{
-    "accept" = "application/json"
-    "content-type" = "application/json"
-    "X-API-KEY" = Get-AteraAPIKey
-  }
+  $Headers = Get-AteraAuthHeaders
+  $Headers["content-type"] = "application/json"
   $Uri = "https://app.atera.com/api/v3$($endpoint)"
   Write-Debug "[PSAtera] Request for $Uri"
   $JsonBody = ConvertTo-Json -InputObject $Body -Depth 10
@@ -122,14 +113,14 @@ function New-AteraPutRequest {
 $AteraAPIKey = $env:ATERAAPIKEY
 <#
   .Synopsis
-  Set the Atera API Key used by the module. If none set, the ATERAAPIKEY environment variable will be used instead.
+  Set the Atera API token used by the module. If none set, the ATERAAPIKEY environment variable will be used instead.
 
   .Parameter APIKey
-  Atera API Key which can be found at https://app.atera.com/Admin#/admin/api
+  Atera JWT token which can be found at https://app.atera.com/new/admin/api
 #>
 function Set-AteraAPIKey {
   param(
-    # Atera API Key
+    # Atera JWT token
     [string]$APIKey
   )
   $script:AteraAPIKey = $APIKey
@@ -137,11 +128,22 @@ function Set-AteraAPIKey {
 
 <#
   .Synopsis
-  Get the Atera API Key in use by the module.
+  Get the Atera API token in use by the module.
 #>
 function Get-AteraAPIKey {
   if (!$AteraAPIKey) { throw "`$AteraAPIKey not set. Set it with either Set-AteraAPIKey or `$env:ATERAAPIKEY" }
   return $AteraAPIKey
+}
+
+<#
+  .Synopsis
+  Build request headers for Atera API calls using Bearer JWT authentication.
+#>
+function Get-AteraAuthHeaders {
+  @{
+    "accept" = "application/json"
+    "Authorization" = "Bearer $(Get-AteraAPIKey)"
+  }
 }
 
 $RecordLimit = 1000

--- a/README.md
+++ b/README.md
@@ -7,16 +7,21 @@ Start interacting with Atera from PowerShell with the PSAtera module.
 
 ## Configuration
 
-The PSAtera module relies on the `ATERAAPIKEY` environment variable for the API token for your Atera account, which can be found here:
+The PSAtera module relies on the `ATERAAPIKEY` environment variable for the API key or token for your Atera account, which can be found here:
 https://app.atera.com/new/admin/api
 
-You can also set the token at runtime with `Set-AteraAPIKey`.
+You can also set the key at runtime with `Set-AteraAPIKey`.
 
-### API authentication change
+### API authentication
 
-Atera now uses JWT Bearer authentication instead of the legacy `X-API-KEY` header. Recent versions of PSAtera send requests as `Authorization: Bearer {token}`.
+Atera is moving from legacy static API keys (`X-API-KEY` header) to JWT Bearer tokens (`Authorization: Bearer {token}`). Legacy keys remain valid for **60 days** after the change—plan to replace yours with a JWT before that deadline.
 
-**If you upgrade PSAtera, update every script and automation that talks to Atera:** replace your old API key with the new JWT token from the Atera admin portal. The `Set-AteraAPIKey` cmdlet and `ATERAAPIKEY` environment variable names are unchanged—only the token value format has changed.
+PSAtera detects the format automatically based on token length:
+
+- **Short keys** (100 characters or fewer) are sent as `X-API-KEY` for backward compatibility with existing scripts.
+- **Long keys** (more than 100 characters) are sent as `Authorization: Bearer {token}` for the new JWT format.
+
+No code changes are required when upgrading: keep using `Set-AteraAPIKey` and `ATERAAPIKEY` as before. When Atera rotates your credentials to a JWT, PSAtera will switch to Bearer authentication automatically.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,16 @@ Start interacting with Atera from PowerShell with the PSAtera module.
 
 ## Configuration
 
-The PSAtera module relies on the `ATERAAPIKEY` environment variable for the API key for your Atera account which can be found here:
+The PSAtera module relies on the `ATERAAPIKEY` environment variable for the API token for your Atera account, which can be found here:
 https://app.atera.com/new/admin/api
+
+You can also set the token at runtime with `Set-AteraAPIKey`.
+
+### API authentication change
+
+Atera now uses JWT Bearer authentication instead of the legacy `X-API-KEY` header. Recent versions of PSAtera send requests as `Authorization: Bearer {token}`.
+
+**If you upgrade PSAtera, update every script and automation that talks to Atera:** replace your old API key with the new JWT token from the Atera admin portal. The `Set-AteraAPIKey` cmdlet and `ATERAAPIKEY` environment variable names are unchanged—only the token value format has changed.
 
 ## Install
 


### PR DESCRIPTION
Atera published a new API key format (Bearer)
Doc can be found here: https://support.atera.com/hc/en-us/articles/219083397-Using-the-Atera-API

Please upgrade your Atera scripts fast because old key won't be functionnal after 60 days.