### PR TITLE
New API upgrade - new methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.8.0] - 2026/06/16
+### Added
+- API authentication now supports Atera JWT Bearer tokens in addition to legacy `X-API-KEY` headers. The module detects the format automatically by token length (short keys use `X-API-KEY`, keys longer than 100 characters use `Authorization: Bearer {token}`). Existing scripts using `Set-AteraAPIKey` or `ATERAAPIKEY` require no code changes.
+- New generic request helper `New-AteraDeleteRequest` for DELETE operations against the API.
+- `Get-AteraAccount` — account information (`GET /account`).
+- `Get-AteraWorkHours` — workhour records with optional date and rate filters.
+- **Departments:** `Get-AteraDepartments`, `Get-AteraDepartment`, `New-AteraDepartment`, `Set-AteraDepartment`, `Remove-AteraDepartment`.
+- **Devices:** Generic, TCP, HTTP, and SNMP device cmdlets including list, get, create, and delete operations; `Get-AteraSnmpDeviceByGuid`, `New-AteraSnmpDeviceV1V2`, `New-AteraSnmpDeviceV3`.
+- **Tickets:** `Get-AteraTicketsWithoutComments`, `Get-AteraTicketsByStatusModified`, `Get-AteraTicketsByLastModified`, `Get-AteraTicketAttachments`, `New-AteraTicketWorkHours`, `Add-AteraTicketRelation`, `Remove-AteraTicketRelation`, `Remove-AteraTicket`.
+- **Customers:** `Set-AteraCustomer`, `Remove-AteraCustomer`, `New-AteraCustomerFolder`, `New-AteraCustomerAttachment`.
+- **Contacts:** `Set-AteraContact`, `Remove-AteraContact`.
+- **Contracts:** `New-AteraContract`, `Set-AteraContract`.
+- **Rates:** `Set-AteraProduct`, `Remove-AteraProduct`, `Set-AteraExpense`, `Remove-AteraExpense`.
+- **Agents:** `Get-AteraAgentInstalledPatches`, `Get-AteraAgentAvailablePatches`, `Remove-AteraAgent`.
+- **Alerts:** `Remove-AteraAlert`.
+- **Custom values:** `Get-AteraCustomValuesForObject`, `New-AteraCustomValue`, `Get-AteraCustomValueById`.
+
+### Fixed
+- `Set-AteraTicket`: `-TicketTitle` was ignored due to a typo in the parameter check (`$TickeTitle`).
+
+### Changed
+- Module exports now include `Remove-Atera*` and `Add-Atera*` cmdlets in addition to existing `Get-Atera*`, `Set-Atera*`, and `New-Atera*` patterns.
+- `New-AteraPutRequest` and `New-AteraDeleteRequest` are included in the published function list.
+
+### Notes
+- Legacy API keys remain supported during Atera's transition period. Replace your key with a JWT from the Atera admin portal before legacy keys expire.
+- Do not prefix the token with `Bearer ` in `ATERAAPIKEY` or `Set-AteraAPIKey`; the module adds the scheme automatically for JWT tokens.
+
 ## [1.7.1] - 2025/09/05
 ### Fixed
 -  `Get-AteraAgent`: if we have multiple computers matched, sort agents by latest seen agent

--- a/PSAtera/PSAtera.psd1
+++ b/PSAtera/PSAtera.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSAtera.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.7.1'
+ModuleVersion = '1.8.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -69,22 +69,33 @@ ScriptsToProcess = 'PostInstall.ps1'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Get-AteraAgents', 'Get-AteraAgent', 'Get-AteraAlerts', 
-               'Get-AteraAlert', 'Get-AteraAlertsFiltered', 'Set-AteraAlert', 'New-AteraAlert', 
-               'Get-AteraInvoices', 'Get-AteraInvoice', 'Get-AteraContacts', 
-               'Get-AteraContact', 'New-AteraContact', 'Get-AteraContracts', 
-               'Get-AteraContract', 'Get-AteraCustomers', 'Get-AteraCustomer', 
-               'New-AteraCustomer', 'Get-AteraCustomValues', 'Get-AteraCustomValue', 'Set-AteraCustomValue', 
-               'Get-AteraKnowledgebase', 'Get-AteraProducts', 'Get-AteraExpenses', 
-               'Get-AteraProduct', 'Get-AteraExpense', 'New-AteraProduct', 
-               'New-AteraExpense', 'Get-AteraTickets', 'Get-AteraTicket', 
-               'Get-AteraTicketBillableDuration', 
-               'Get-AteraTicketNonBillableDuration', 'Get-AteraTicketWorkHours', 
-               'Get-AteraTicketWorkHoursList', 'Get-AteraTicketComments', 
-               'Get-AteraTicketsFiltered', 'New-AteraTicket', 'New-AteraTicketComment', 'Set-AteraTicket', 
-               'Install-AteraAgent', 'Get-AteraAPIKey', 'Set-AteraAPIKey', 
-               'Get-AteraRecordLimit', 'Set-AteraRecordLimit', 'New-AteraGetRequest', 
-               'New-AteraPostRequest'
+FunctionsToExport = 'Add-AteraTicketRelation', 'Get-AteraAccount', 'Get-AteraAgent',
+               'Get-AteraAgentAvailablePatches', 'Get-AteraAgentInstalledPatches', 'Get-AteraAgents',
+               'Get-AteraAlert', 'Get-AteraAlerts', 'Get-AteraAlertsFiltered', 'Get-AteraAPIKey',
+               'Get-AteraContact', 'Get-AteraContacts', 'Get-AteraContract', 'Get-AteraContracts',
+               'Get-AteraCustomer', 'Get-AteraCustomers', 'Get-AteraCustomValue', 'Get-AteraCustomValueById',
+               'Get-AteraCustomValues', 'Get-AteraCustomValuesForObject', 'Get-AteraDepartment',
+               'Get-AteraDepartments', 'Get-AteraExpense', 'Get-AteraExpenses', 'Get-AteraGenericDevice',
+               'Get-AteraGenericDevices', 'Get-AteraHttpDevice', 'Get-AteraHttpDevices', 'Get-AteraInvoice',
+               'Get-AteraInvoices', 'Get-AteraKnowledgebase', 'Get-AteraProduct', 'Get-AteraProducts',
+               'Get-AteraRecordLimit', 'Get-AteraSnmpDevice', 'Get-AteraSnmpDeviceByGuid', 'Get-AteraSnmpDevices',
+               'Get-AteraTcpDevice', 'Get-AteraTcpDevices', 'Get-AteraTicket', 'Get-AteraTicketAttachments',
+               'Get-AteraTicketBillableDuration', 'Get-AteraTicketComments', 'Get-AteraTicketNonBillableDuration',
+               'Get-AteraTickets', 'Get-AteraTicketsByLastModified', 'Get-AteraTicketsByStatusModified',
+               'Get-AteraTicketsFiltered', 'Get-AteraTicketsWithoutComments', 'Get-AteraTicketWorkHours',
+               'Get-AteraTicketWorkHoursList', 'Get-AteraWorkHours', 'Install-AteraAgent', 'New-AteraAlert',
+               'New-AteraContact', 'New-AteraContract', 'New-AteraCustomer', 'New-AteraCustomerAttachment',
+               'New-AteraCustomerFolder', 'New-AteraCustomValue', 'New-AteraDeleteRequest', 'New-AteraDepartment',
+               'New-AteraExpense', 'New-AteraGenericDevice', 'New-AteraGetRequest', 'New-AteraHttpDevice',
+               'New-AteraPostRequest', 'New-AteraProduct', 'New-AteraPutRequest', 'New-AteraSnmpDeviceV1V2',
+               'New-AteraSnmpDeviceV3', 'New-AteraTcpDevice', 'New-AteraTicket', 'New-AteraTicketComment',
+               'New-AteraTicketWorkHours', 'Remove-AteraAgent', 'Remove-AteraAlert', 'Remove-AteraContact',
+               'Remove-AteraCustomer', 'Remove-AteraDepartment', 'Remove-AteraExpense', 'Remove-AteraGenericDevice',
+               'Remove-AteraHttpDevice', 'Remove-AteraProduct', 'Remove-AteraSnmpDevice', 'Remove-AteraTcpDevice',
+               'Remove-AteraTicket', 'Remove-AteraTicketRelation', 'Set-AteraAlert', 'Set-AteraAPIKey',
+               'Set-AteraContact', 'Set-AteraContract', 'Set-AteraCustomer', 'Set-AteraCustomValue',
+               'Set-AteraDepartment', 'Set-AteraExpense', 'Set-AteraProduct', 'Set-AteraRecordLimit',
+               'Set-AteraTicket'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/PSAtera/PSAtera.psm1
+++ b/PSAtera/PSAtera.psm1
@@ -109,6 +109,30 @@ function New-AteraPutRequest {
   return $data
 }
 
+<#
+  .Synopsis
+  Generic command for making DELETE requests against the Atera API
+
+  .Parameter Endpoint
+  Endpoint to request, beginning with a /
+
+  .Example
+  New-AteraDeleteRequest -Endpoint "/tickets/1234"
+  # Delete ticket 1234
+#>
+function New-AteraDeleteRequest {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [string] $Endpoint
+  )
+  $Headers = Get-AteraAuthHeaders
+  $Uri = "https://app.atera.com/api/v3$($endpoint)"
+  Write-Debug "[PSAtera] Request for $Uri"
+  $data = Invoke-RestMethod -Uri $Uri -Method "DELETE" -Headers $Headers
+  return $data
+}
+
 
 $AteraAPIKey = $env:ATERAAPIKEY
 # Legacy static API keys are short; JWT tokens issued by Atera are much longer.
@@ -234,4 +258,4 @@ function Format-QueryString($Query) {
 
 Get-ChildItem -Path $PSScriptRoot/endpoints | ForEach-Object { . $_.PSPath }
 
-Export-ModuleMember -Function Install-AteraAgent,Get-Atera*,Set-Atera*,New-Atera*
+Export-ModuleMember -Function Install-AteraAgent,Get-Atera*,Set-Atera*,New-Atera*,Remove-Atera*,Add-Atera*

--- a/PSAtera/endpoints/Account.ps1
+++ b/PSAtera/endpoints/Account.ps1
@@ -1,0 +1,9 @@
+<#
+  .Synopsis
+  Get account information from the Atera API.
+#>
+function Get-AteraAccount {
+  [CmdletBinding()]
+  param()
+  New-AteraGetRequest -Endpoint "/account" -Paginate $false
+}

--- a/PSAtera/endpoints/Agents.ps1
+++ b/PSAtera/endpoints/Agents.ps1
@@ -83,3 +83,42 @@ function Get-AteraAgent {
     return $machines | Sort-Object LastSeen -Descending
   }
 }
+
+<#
+  .Synopsis
+  Get installed patches for an agent.
+#>
+function Get-AteraAgentInstalledPatches {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)]
+    [string] $DeviceGuid
+  )
+  New-AteraGetRequest -Endpoint "/agents/$DeviceGuid/installed-patches" -Paginate $false
+}
+
+<#
+  .Synopsis
+  Get available patches for an agent.
+#>
+function Get-AteraAgentAvailablePatches {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)]
+    [string] $DeviceGuid
+  )
+  New-AteraGetRequest -Endpoint "/agents/$DeviceGuid/available-patches" -Paginate $false
+}
+
+<#
+  .Synopsis
+  Delete an agent.
+#>
+function Remove-AteraAgent {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)]
+    [int] $AgentID
+  )
+  New-AteraDeleteRequest -Endpoint "/agents/$AgentID"
+}

--- a/PSAtera/endpoints/Alerts.ps1
+++ b/PSAtera/endpoints/Alerts.ps1
@@ -196,3 +196,16 @@ function Set-AteraAlert {
   )
   New-AteraPutRequest -Endpoint "/alerts/$AlertID"
 }
+
+<#
+  .Synopsis
+  Delete a specified alert.
+#>
+function Remove-AteraAlert {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+    [string] $AlertID
+  )
+  New-AteraDeleteRequest -Endpoint "/alerts/$AlertID"
+}

--- a/PSAtera/endpoints/Contacts.ps1
+++ b/PSAtera/endpoints/Contacts.ps1
@@ -74,3 +74,44 @@ function New-AteraContact {
   )
   New-AteraPostRequest -Endpoint "/contacts" -Body $PSBoundParameters
 }
+
+<#
+  .Synopsis
+  Update an existing contact.
+#>
+function Set-AteraContact {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [int] $ContactID,
+    [Parameter()]
+    [string] $FirstName,
+    [Parameter()]
+    [string] $LastName,
+    [Parameter()]
+    [string] $JobTitle,
+    [Parameter()]
+    [string] $Phone,
+    [Parameter()]
+    [bool] $IsContactPerson,
+    [Parameter()]
+    [string] $InIgnoreMode
+  )
+  $Body = @{} + $PSBoundParameters
+  $null = $Body.Remove("ContactID")
+  if (!$Body.Count) { throw "At least one update parameter needs to be set" }
+  New-AteraPutRequest -Endpoint "/contacts/$ContactID" -Body $Body
+}
+
+<#
+  .Synopsis
+  Delete an existing contact.
+#>
+function Remove-AteraContact {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [int] $ContactID
+  )
+  New-AteraDeleteRequest -Endpoint "/contacts/$ContactID"
+}

--- a/PSAtera/endpoints/Contracts.ps1
+++ b/PSAtera/endpoints/Contracts.ps1
@@ -28,3 +28,31 @@ function Get-AteraContract {
   )
   return New-AteraGetRequest -Endpoint "/contracts/$ContractID" -Paginate $false
 }
+
+<#
+  .Synopsis
+  Create a new contract.
+#>
+function New-AteraContract {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [Hashtable] $Body
+  )
+  New-AteraPostRequest -Endpoint "/contracts" -Body $Body
+}
+
+<#
+  .Synopsis
+  Update an existing contract.
+#>
+function Set-AteraContract {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [int] $ContractID,
+    [Parameter(Mandatory)]
+    [Hashtable] $Body
+  )
+  New-AteraPutRequest -Endpoint "/contracts/$ContractID" -Body $Body
+}

--- a/PSAtera/endpoints/CustomValues.ps1
+++ b/PSAtera/endpoints/CustomValues.ps1
@@ -83,3 +83,55 @@ function Set-AteraCustomValue {
   $uri = "/customvalues/$($ObjectType.ToLower())field/$ObjectID/$FieldName"
   New-AteraPutRequest -Endpoint $uri -Body @{Value=$Value}
 }
+
+<#
+  .Synopsis
+  Get all custom values for a specific object.
+#>
+function Get-AteraCustomValuesForObject {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [ValidateSet("Ticket", "Customer", "Contact", "Contract", "SLA", "Agent", "SNMP", "TCP", "HTTP", "Generic")]
+    [string] $ObjectType,
+    [Parameter(Mandatory)]
+    [int] $ObjectID
+  )
+  $uri = "/customvalues/$($ObjectType.ToLower())fields/$ObjectID"
+  New-AteraGetRequest -Endpoint $uri -Paginate $false
+}
+
+<#
+  .Synopsis
+  Create a value for a custom field.
+#>
+function New-AteraCustomValue {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [ValidateSet("Ticket", "Customer", "Contact", "Contract", "SLA", "Agent", "SNMP", "TCP", "HTTP", "Generic")]
+    [string] $ObjectType,
+    [Parameter(Mandatory)]
+    [int] $ObjectID,
+    [Parameter(Mandatory)]
+    [string] $FieldName,
+    [Parameter()]
+    [string] $Value = ""
+  )
+  $FieldName = [uri]::EscapeDataString($FieldName)
+  $uri = "/customvalues/$($ObjectType.ToLower())field/$ObjectID/$FieldName"
+  New-AteraPostRequest -Endpoint $uri -Body @{ Value = $Value }
+}
+
+<#
+  .Synopsis
+  Get custom value records by custom value ID.
+#>
+function Get-AteraCustomValueById {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [string] $CustomValueID
+  )
+  New-AteraGetRequest -Endpoint "/customvalues/$CustomValueID" -Paginate $false
+}

--- a/PSAtera/endpoints/Customers.ps1
+++ b/PSAtera/endpoints/Customers.ps1
@@ -78,3 +78,94 @@ function New-AteraCustomer {
   )
   New-AteraPostRequest -Endpoint "/customers" -Body $PSBoundParameters
 }
+
+<#
+  .Synopsis
+  Updates an existing customer.
+#>
+function Set-AteraCustomer {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [int] $CustomerID,
+    [Parameter()]
+    [string] $CustomerName,
+    [Parameter()]
+    [string] $BusinessNumber,
+    [Parameter()]
+    [string] $Domain,
+    [Parameter()]
+    [string] $Address,
+    [Parameter()]
+    [string] $City,
+    [Parameter()]
+    [string] $State,
+    [Parameter()]
+    [string] $ZipCodeStr,
+    [Parameter()]
+    [string] $Country,
+    [Parameter()]
+    [string] $Phone,
+    [Parameter()]
+    [string] $Fax,
+    [Parameter()]
+    [string] $Notes,
+    [Parameter()]
+    [string] $Links,
+    [Parameter()]
+    [string] $Longitude,
+    [Parameter()]
+    [string] $Latitude
+  )
+  $Body = @{} + $PSBoundParameters
+  $null = $Body.Remove("CustomerID")
+  if (!$Body.Count) { throw "At least one update parameter needs to be set" }
+  New-AteraPutRequest -Endpoint "/customers/$CustomerID" -Body $Body
+}
+
+<#
+  .Synopsis
+  Deletes an existing customer.
+#>
+function Remove-AteraCustomer {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [int] $CustomerID
+  )
+  New-AteraDeleteRequest -Endpoint "/customers/$CustomerID"
+}
+
+<#
+  .Synopsis
+  Creates a customer folder.
+#>
+function New-AteraCustomerFolder {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [string] $Name,
+    [Parameter(Mandatory)]
+    [int] $CustomerID,
+    [Parameter()]
+    [int] $ThresholdId
+  )
+  New-AteraPostRequest -Endpoint "/customers/folders" -Body $PSBoundParameters
+}
+
+<#
+  .Synopsis
+  Creates a customer attachment from base64 content.
+#>
+function New-AteraCustomerAttachment {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [int] $CustomerID,
+    [Parameter(Mandatory)]
+    [string] $AttachmentName,
+    [Parameter(Mandatory)]
+    [string] $AttachmentContentBase64
+  )
+  New-AteraPostRequest -Endpoint "/customers/attachments" -Body $PSBoundParameters
+}

--- a/PSAtera/endpoints/Departments.ps1
+++ b/PSAtera/endpoints/Departments.ps1
@@ -1,0 +1,65 @@
+<#
+  .Synopsis
+  Get a list of departments.
+#>
+function Get-AteraDepartments {
+  [CmdletBinding()]
+  param()
+  New-AteraGetRequest -Endpoint "/departments"
+}
+
+<#
+  .Synopsis
+  Get a specific department.
+#>
+function Get-AteraDepartment {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)]
+    [int] $DepartmentID
+  )
+  New-AteraGetRequest -Endpoint "/departments/$DepartmentID" -Paginate $false
+}
+
+<#
+  .Synopsis
+  Create a department.
+#>
+function New-AteraDepartment {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)]
+    [string] $Name,
+    [Parameter()]
+    [string] $Description
+  )
+  New-AteraPostRequest -Endpoint "/departments" -Body $PSBoundParameters
+}
+
+<#
+  .Synopsis
+  Update a department.
+#>
+function Set-AteraDepartment {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)]
+    [int] $DepartmentID,
+    [Parameter(Mandatory)]
+    [Hashtable] $Body
+  )
+  New-AteraPutRequest -Endpoint "/departments/$DepartmentID" -Body $Body
+}
+
+<#
+  .Synopsis
+  Delete a department.
+#>
+function Remove-AteraDepartment {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)]
+    [int] $DepartmentID
+  )
+  New-AteraDeleteRequest -Endpoint "/departments/$DepartmentID"
+}

--- a/PSAtera/endpoints/Devices.ps1
+++ b/PSAtera/endpoints/Devices.ps1
@@ -1,0 +1,135 @@
+<#
+  .Synopsis
+  Get generic devices.
+#>
+function Get-AteraGenericDevices {
+  [CmdletBinding()]
+  param(
+    [Parameter()]
+    [Hashtable] $Query
+  )
+  New-AteraGetRequest -Endpoint "/devices/genericdevices" -Query $Query
+}
+
+function Get-AteraGenericDevice {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][int] $DeviceID)
+  New-AteraGetRequest -Endpoint "/devices/genericdevice/$DeviceID" -Paginate $false
+}
+
+function New-AteraGenericDevice {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][Hashtable] $Body)
+  New-AteraPostRequest -Endpoint "/devices/genericdevice" -Body $Body
+}
+
+function Remove-AteraGenericDevice {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][int] $DeviceID)
+  New-AteraDeleteRequest -Endpoint "/devices/genericdevice/$DeviceID"
+}
+
+<#
+  .Synopsis
+  Get TCP devices.
+#>
+function Get-AteraTcpDevices {
+  [CmdletBinding()]
+  param(
+    [Parameter()]
+    [Hashtable] $Query
+  )
+  New-AteraGetRequest -Endpoint "/devices/tcpdevices" -Query $Query
+}
+
+function Get-AteraTcpDevice {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][int] $DeviceID)
+  New-AteraGetRequest -Endpoint "/devices/tcpdevice/$DeviceID" -Paginate $false
+}
+
+function New-AteraTcpDevice {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][Hashtable] $Body)
+  New-AteraPostRequest -Endpoint "/devices/tcpdevice" -Body $Body
+}
+
+function Remove-AteraTcpDevice {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][int] $DeviceID)
+  New-AteraDeleteRequest -Endpoint "/devices/tcpdevice/$DeviceID"
+}
+
+<#
+  .Synopsis
+  Get HTTP devices.
+#>
+function Get-AteraHttpDevices {
+  [CmdletBinding()]
+  param(
+    [Parameter()]
+    [Hashtable] $Query
+  )
+  New-AteraGetRequest -Endpoint "/devices/httpdevices" -Query $Query
+}
+
+function Get-AteraHttpDevice {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][int] $DeviceID)
+  New-AteraGetRequest -Endpoint "/devices/httpdevice/$DeviceID" -Paginate $false
+}
+
+function New-AteraHttpDevice {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][Hashtable] $Body)
+  New-AteraPostRequest -Endpoint "/devices/httpdevice" -Body $Body
+}
+
+function Remove-AteraHttpDevice {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][int] $DeviceID)
+  New-AteraDeleteRequest -Endpoint "/devices/httpdevice/$DeviceID"
+}
+
+<#
+  .Synopsis
+  Get SNMP devices.
+#>
+function Get-AteraSnmpDevices {
+  [CmdletBinding()]
+  param(
+    [Parameter()]
+    [Hashtable] $Query
+  )
+  New-AteraGetRequest -Endpoint "/devices/snmpdevices" -Query $Query
+}
+
+function Get-AteraSnmpDevice {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][int] $DeviceID)
+  New-AteraGetRequest -Endpoint "/devices/snmpdevice/$DeviceID" -Paginate $false
+}
+
+function Get-AteraSnmpDeviceByGuid {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][string] $DeviceGuid)
+  New-AteraGetRequest -Endpoint "/devices/snmpdevice/guid/$DeviceGuid" -Paginate $false
+}
+
+function New-AteraSnmpDeviceV1V2 {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][Hashtable] $Body)
+  New-AteraPostRequest -Endpoint "/devices/snmpdevice/v1v2" -Body $Body
+}
+
+function New-AteraSnmpDeviceV3 {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][Hashtable] $Body)
+  New-AteraPostRequest -Endpoint "/devices/snmpdevice/v3" -Body $Body
+}
+
+function Remove-AteraSnmpDevice {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][int] $DeviceID)
+  New-AteraDeleteRequest -Endpoint "/devices/snmpdevice/$DeviceID"
+}

--- a/PSAtera/endpoints/Rates.ps1
+++ b/PSAtera/endpoints/Rates.ps1
@@ -98,3 +98,59 @@ function New-AteraExpense {
   )
   New-AteraPostRequest -Endpoint "/rates/expenses" -Body $PSBoundParameters
 }
+
+<#
+  .Synopsis
+  Update a product.
+#>
+function Set-AteraProduct {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [int] $ProductID,
+    [Parameter(Mandatory)]
+    [Hashtable] $Body
+  )
+  New-AteraPutRequest -Endpoint "/rates/products/$ProductID" -Body $Body
+}
+
+<#
+  .Synopsis
+  Delete a product.
+#>
+function Remove-AteraProduct {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [int] $ProductID
+  )
+  New-AteraDeleteRequest -Endpoint "/rates/products/$ProductID"
+}
+
+<#
+  .Synopsis
+  Update an expense.
+#>
+function Set-AteraExpense {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [int] $ExpenseID,
+    [Parameter(Mandatory)]
+    [Hashtable] $Body
+  )
+  New-AteraPutRequest -Endpoint "/rates/expenses/$ExpenseID" -Body $Body
+}
+
+<#
+  .Synopsis
+  Delete an expense.
+#>
+function Remove-AteraExpense {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [int] $ExpenseID
+  )
+  New-AteraDeleteRequest -Endpoint "/rates/expenses/$ExpenseID"
+}

--- a/PSAtera/endpoints/Tickets.ps1
+++ b/PSAtera/endpoints/Tickets.ps1
@@ -56,6 +56,90 @@ function Get-AteraTickets {
 
 <#
   .Synopsis
+  Get tickets without comments.
+
+  .Parameter CustomerID
+  Optional customer ID filter.
+
+  .Parameter TicketStatus
+  Optional ticket status filter.
+
+  .Parameter IncludeRelations
+  Include related ticket metadata.
+#>
+function Get-AteraTicketsWithoutComments {
+  [CmdletBinding()]
+  param(
+    [Parameter()]
+    [int] $CustomerID,
+    [Parameter()]
+    [string] $TicketStatus,
+    [Parameter()]
+    [bool] $IncludeRelations = $false
+  )
+  $Query = @{ includeRelations = $IncludeRelations }
+  if ($PSBoundParameters.ContainsKey("CustomerID")) { $Query.customerId = $CustomerID }
+  if ($PSBoundParameters.ContainsKey("TicketStatus")) { $Query.ticketStatus = $TicketStatus }
+  return New-AteraGetRequest -Endpoint "/tickets/noComments" -Query $Query
+}
+
+<#
+  .Synopsis
+  Get resolved and closed tickets sorted by status modification date.
+
+  .Parameter IncludeComments
+  Include first/last comment details.
+
+  .Parameter IncludeRelations
+  Include related ticket metadata.
+#>
+function Get-AteraTicketsByStatusModified {
+  [CmdletBinding()]
+  param(
+    [Parameter()]
+    [bool] $IncludeComments = $true,
+    [Parameter()]
+    [bool] $IncludeRelations = $false
+  )
+  return New-AteraGetRequest -Endpoint "/tickets/statusmodified" -Query @{
+    includeComments = $IncludeComments
+    includeRelations = $IncludeRelations
+  }
+}
+
+<#
+  .Synopsis
+  Get tickets ordered by last modified date.
+
+  .Parameter Date
+  UTC date filter in ISO 8601 format.
+
+  .Parameter IncludeComments
+  Include the ticket's latest comments.
+
+  .Parameter IncludeRelations
+  Include related ticket metadata.
+#>
+function Get-AteraTicketsByLastModified {
+  [CmdletBinding()]
+  param(
+    [Parameter()]
+    [string] $Date,
+    [Parameter()]
+    [bool] $IncludeComments = $false,
+    [Parameter()]
+    [bool] $IncludeRelations = $false
+  )
+  $Query = @{
+    includeComments = $IncludeComments
+    includeRelations = $IncludeRelations
+  }
+  if ($PSBoundParameters.ContainsKey("Date")) { $Query.date = $Date }
+  return New-AteraGetRequest -Endpoint "/tickets/lastmodified" -Query $Query
+}
+
+<#
+  .Synopsis
   Get a single ticket by it's ID
 
   .Parameter TicketID
@@ -135,6 +219,21 @@ function Get-AteraTicketComments {
     [int]$TicketID
   )
   return New-AteraGetRequest -Endpoint "/tickets/$TicketID/comments"
+}
+
+<#
+  .Synopsis
+  Get all attachment URLs on a ticket.
+
+  .Parameter TicketID
+  ID of ticket to retrieve.
+#>
+function Get-AteraTicketAttachments {
+  param(
+    [Parameter(Mandatory)]
+    [int]$TicketID
+  )
+  return New-AteraGetRequest -Endpoint "/tickets/$TicketID/attachments" -Paginate $false
 }
 
 <#
@@ -262,7 +361,7 @@ function Set-AteraTicket {
     [int] $TechnicianContactID
   )
   $Body = @{}
-  if ($TickeTitle -ne "") { $Body["TicketTitle"] = $TicketTitle }
+  if ($TicketTitle -ne "") { $Body["TicketTitle"] = $TicketTitle }
   if ($TicketStatus -ne "") { $Body.TicketStatus = $TicketStatus }
   if ($TicketType -ne "") { $Body.TicketType = $TicketType }
   if ($TicketPriority -ne "") { $Body.TicketPriority = $TicketPriority }
@@ -271,6 +370,22 @@ function Set-AteraTicket {
   if (!$Body.Count) { throw "At least one update parameter needs to be set" }
 
   New-AteraPostRequest -Endpoint "/tickets/$($TicketID)" -Body $Body
+}
+
+<#
+  .Synopsis
+  Delete a ticket.
+
+  .Parameter TicketID
+  Ticket ID to delete.
+#>
+function Remove-AteraTicket {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+    [int] $TicketID
+  )
+  New-AteraDeleteRequest -Endpoint "/tickets/$TicketID"
 }
 
 <#
@@ -326,4 +441,70 @@ function New-AteraTicketComment {
   if (!$Body.Count) { throw "At least one update parameter needs to be set" }
 
   New-AteraPostRequest -Endpoint "/tickets/$($TicketID)/comments" -Body $Body
+}
+
+<#
+  .Synopsis
+  Add work hours entry to a ticket.
+#>
+function New-AteraTicketWorkHours {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory)]
+    [int] $TicketID,
+    [Parameter(Mandatory)]
+    [string] $StartWorkHour,
+    [Parameter(Mandatory)]
+    [string] $EndWorkHour,
+    [Parameter()]
+    [int] $TechnicianContactID,
+    [Parameter()]
+    [string] $TechnicianEmail,
+    [Parameter()]
+    [bool] $Billiable = $true,
+    [Parameter()]
+    [bool] $OnCustomerSite = $false,
+    [Parameter()]
+    [string] $Comments
+  )
+  $Body = @{} + $PSBoundParameters
+  $null = $Body.Remove("TicketID")
+  New-AteraPostRequest -Endpoint "/tickets/$TicketID/workhours" -Body $Body
+}
+
+<#
+  .Synopsis
+  Link a ticket relation as Parent or Child.
+#>
+function Add-AteraTicketRelation {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)]
+    [int] $TicketID,
+    [Parameter(Mandatory)]
+    [int] $RelatedTicketId,
+    [Parameter(Mandatory)]
+    [ValidateSet("Parent", "Child")]
+    [string] $RelationType
+  )
+  New-AteraPostRequest -Endpoint "/tickets/$TicketID/relations" -Body @{
+    RelatedTicketId = $RelatedTicketId
+    RelationType = $RelationType
+  }
+}
+
+<#
+  .Synopsis
+  Remove a Parent or Child ticket relation.
+#>
+function Remove-AteraTicketRelation {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)]
+    [int] $TicketID,
+    [Parameter(Mandatory)]
+    [ValidateSet("Parent", "Child")]
+    [string] $RelationType
+  )
+  New-AteraDeleteRequest -Endpoint "/tickets/$TicketID/relations/$RelationType"
 }

--- a/PSAtera/endpoints/Workhours.ps1
+++ b/PSAtera/endpoints/Workhours.ps1
@@ -1,0 +1,21 @@
+<#
+  .Synopsis
+  Get workhour records with optional date/rate filters.
+#>
+function Get-AteraWorkHours {
+  [CmdletBinding()]
+  param(
+    [Parameter()]
+    [string] $StartWorkhour,
+    [Parameter()]
+    [string] $EndWorkhour,
+    [Parameter()]
+    [bool] $IncludeRates = $false
+  )
+  $Query = @{
+    includeRates = $IncludeRates
+  }
+  if ($PSBoundParameters.ContainsKey("StartWorkhour")) { $Query.startWorkhour = $StartWorkhour }
+  if ($PSBoundParameters.ContainsKey("EndWorkhour")) { $Query.endWorkhour = $EndWorkhour }
+  New-AteraGetRequest -Endpoint "/workhours" -Query $Query
+}

--- a/PSAtera/psakefile.ps1
+++ b/PSAtera/psakefile.ps1
@@ -9,7 +9,7 @@ Task FunctionsToExport {
       $ast.EndBlock.Statements.Name
     }
   }
-  $functionNames += @("Install-AteraAgent", "Get-AteraAPIKey", "Set-AteraAPIKey", "Get-AteraRecordLimit", "Set-AteraRecordLimit", "New-AteraGetRequest", "New-AteraPostRequest")
+  $functionNames += @("Install-AteraAgent", "Get-AteraAPIKey", "Set-AteraAPIKey", "Get-AteraRecordLimit", "Set-AteraRecordLimit", "New-AteraGetRequest", "New-AteraPostRequest", "New-AteraPutRequest", "New-AteraDeleteRequest")
   Write-Verbose "Using functions $functionNames"
   
   Update-ModuleManifest -Path ".\$($moduleName).psd1" -FunctionsToExport $functionNames

--- a/atera-openapi.yaml
+++ b/atera-openapi.yaml
@@ -1,0 +1,13343 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "Welcome to the Atera API",
+    "description": "Atera OpenAPI v3 documentation",
+    "termsOfService": "https://www.atera.com/terms-of-service/",
+    "version": "v3"
+  },
+  "paths": {
+    "/api/v3/account": {
+      "get": {
+        "tags": [
+          "Account"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountInfoResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountInfoResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountInfoResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/agents": {
+      "get": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Find agents",
+        "description": "Returns a list of agents.\n\n \nPlease note that the property 'LastPatchManagementReceived' is no longer supported and will return a null reference.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index, based on items per page (default is 1)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/agents/customer/{customerId}": {
+      "get": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Find agents for specified customer",
+        "description": "Returns agents for a specified customer. Requires the customer ID.\n\n \nPlease note that the property 'LastPatchManagementReceived' is no longer supported and will return a null reference.",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "description": "Required - Customer ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index, based on items per page (default is 1)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/agents/{agentId}": {
+      "get": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Get specified agent",
+        "description": "Returns an agent. Requires the agent ID.\n\n \nPlease note that the property 'LastPatchManagementReceived' is no longer supported and will return a null reference.",
+        "parameters": [
+          {
+            "name": "agentId",
+            "in": "path",
+            "description": "Required - System agent ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Delete specified agent",
+        "description": "Deletes an agent. Requires the agent ID.",
+        "parameters": [
+          {
+            "name": "agentId",
+            "in": "path",
+            "description": "Required - System agent ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/agents/machine/{machineName}": {
+      "get": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Get agents for specified machine.",
+        "description": "Returns agents installed on a specified machine. Requires the machine name.\n\n \nPlease note that the property 'LastPatchManagementReceived' is no longer supported and will return a null reference.",
+        "parameters": [
+          {
+            "name": "machineName",
+            "in": "path",
+            "description": "Required - System machine name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index (based on items per page)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page. Default is 20",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/agents/{deviceGuid}/installed-patches": {
+      "get": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Get installed patches for specified agent.",
+        "description": "Returns the installed patches on the agent. Requires the Device guid.",
+        "parameters": [
+          {
+            "name": "deviceGuid",
+            "in": "path",
+            "description": "Required - Device guid",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstalledUpdatesResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstalledUpdatesResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstalledUpdatesResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/agents/{deviceGuid}/available-patches": {
+      "get": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Get available patches for specified agent.",
+        "description": "Returns the available patches on the agent. Requires the Device guid.",
+        "parameters": [
+          {
+            "name": "deviceGuid",
+            "in": "path",
+            "description": "Required - Device guid",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentAvailableUpdatesResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentAvailableUpdatesResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentAvailableUpdatesResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/alerts": {
+      "get": {
+        "tags": [
+          "Alert"
+        ],
+        "summary": "Find alerts",
+        "description": "Returns a list of alerts.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index, based on items per page (default is 20)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "alertStatus",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/AlertStatus"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Alert"
+        ],
+        "summary": "Create alert",
+        "description": "Creates a new alert. Requires the device's global unique identifier (GUID).",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAlertRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAlertRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAlertRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/alerts/{alertId}": {
+      "get": {
+        "tags": [
+          "Alert"
+        ],
+        "summary": "Find specified alert",
+        "description": "Returns an alert. Requires the alert ID.",
+        "parameters": [
+          {
+            "name": "alertId",
+            "in": "path",
+            "description": "Required - System alert ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Alert"
+        ],
+        "summary": "Resolve specified alert",
+        "description": "Resolve a specified alert. Requires the alert ID.",
+        "parameters": [
+          {
+            "name": "alertId",
+            "in": "path",
+            "description": "Required - System alert ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Alert"
+        ],
+        "summary": "Delete specified alert",
+        "description": "Deletes a specified alert. Requires the alert ID.",
+        "parameters": [
+          {
+            "name": "alertId",
+            "in": "path",
+            "description": "Required - System alert ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/billing/invoices": {
+      "get": {
+        "tags": [
+          "Billing"
+        ],
+        "summary": "Find invoices",
+        "description": "Returns a list of invoices. Dates are interpreted in your account's configured timezone.\nString format is used to explicitly specify the yyyy-MM-dd format to avoid ambiguity with different regional date formats.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index, based on items per page (default is 1)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "invoiceDateFrom",
+            "in": "query",
+            "description": "Optional - Filter invoices with invoice date on or after this date in your account's timezone (format: yyyy-MM-dd, e.g., 2025-12-20)",
+            "schema": {
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "type": "string"
+            }
+          },
+          {
+            "name": "invoiceDateTo",
+            "in": "query",
+            "description": "Optional - Filter invoices with invoice date on or before this date in your account's timezone (format: yyyy-MM-dd, e.g., 2025-12-20)",
+            "schema": {
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceDtoPagedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid date format or date range"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/billing/invoice/{invoiceNumber}": {
+      "get": {
+        "tags": [
+          "Billing"
+        ],
+        "summary": "Find specified invoice",
+        "description": "Returns a specified invoice. Requires the invoice number.",
+        "parameters": [
+          {
+            "name": "invoiceNumber",
+            "in": "path",
+            "description": "Required - System invoice number",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/contacts": {
+      "get": {
+        "tags": [
+          "Contact"
+        ],
+        "summary": "Find Contacts",
+        "description": "Accepts whole or partial emails / phone numbers. If partial, will return all contacts whose emails / phone numbers contain the input string.\n\n\nOptionally filter by last modified date (format: yyyy-MM-dd) and specify sort order.\n\n\nDefault sort is by creation date (EndUserId descending). Set sortBy=1 to sort by last modified date.\n\n\nReturn Contact List",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index (default is 1), based on items per page",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "Email",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Phone",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "FromLastModifiedDate",
+            "in": "query",
+            "description": "Optional - Last modified date/time, interpreted in the account's configured timezone (no timezone offset allowed; format: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss, e.g., 2025-01-01 or 2025-01-01T08:30:00). Returns all contacts modified on or after this date.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SortBy",
+            "in": "query",
+            "description": "Optional - Sort order. Default is by Creation (EndUserId).",
+            "schema": {
+              "$ref": "#/components/schemas/ContactSortBy"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request - Invalid parameters",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Contact"
+        ],
+        "summary": "Create contact",
+        "description": "Creates a new contact for an existing customer. Requires the customer ID or the customer name.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateContactRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateContactRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateContactRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/contacts/{contactId}": {
+      "get": {
+        "tags": [
+          "Contact"
+        ],
+        "summary": "Find specified contact",
+        "description": "Returns the specified contact. Requires the contact ID.",
+        "parameters": [
+          {
+            "name": "contactId",
+            "in": "path",
+            "description": "Required - System Contact ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Contact"
+        ],
+        "summary": "Update specified contact",
+        "description": "Updates an existing contact. Requires the contact ID.\n\n\n \nThe following fields are editable:\n\n\n \nFirst Name (Firstname)\n\n\nLast Name (Lastname)\n\n \nJob Title (JobTitle)\n\n\nIs Contact Person (IsContactPerson)\n\n\nIn Ignore Mode (InIgnoreMode)\n\n\nPhone (Phone)",
+        "parameters": [
+          {
+            "name": "contactId",
+            "in": "path",
+            "description": "Required - System Contact ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContactRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContactRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContactRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Contact"
+        ],
+        "summary": "Update specified contact",
+        "description": "Updates an existing contact. Requires the contact ID.\n\n\n \nThe following fields are editable:\n\n\n \nFirst Name (Firstname)\n\n\nLast Name (Lastname)\n\n \nJob Title (JobTitle)\n\n\nIs Contact Person (IsContactPerson)\n\n\nIn Ignore Mode (InIgnoreMode)\n\n\nPhone (Phone)",
+        "parameters": [
+          {
+            "name": "contactId",
+            "in": "path",
+            "description": "Required - System Contact ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContactRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContactRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContactRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Contact"
+        ],
+        "summary": "Delete specified contact",
+        "description": "Deletes the contact. Requires the contact ID.",
+        "parameters": [
+          {
+            "name": "contactId",
+            "in": "path",
+            "description": "Required - System Contact ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/contracts": {
+      "get": {
+        "tags": [
+          "Contract"
+        ],
+        "summary": "Find contracts",
+        "description": "Returns a list of contracts.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index, based on items per page (default is 1)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContractDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContractDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContractDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Contract"
+        ],
+        "summary": "Create Contract",
+        "description": "Creates a new customer. Requires the customer name.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateContractDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateContractDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateContractDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/contracts/{contractId}": {
+      "get": {
+        "tags": [
+          "Contract"
+        ],
+        "parameters": [
+          {
+            "name": "contractId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContractDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContractDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContractDto"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Contract"
+        ],
+        "summary": "Update Contract",
+        "description": "Updates an existing contract. Requires the contract ID.",
+        "parameters": [
+          {
+            "name": "contractId",
+            "in": "path",
+            "description": "Required. System contract ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContractDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContractDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContractDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Contract"
+        ],
+        "summary": "Update Contract",
+        "description": "Updates an existing contract. Requires the contract ID.",
+        "parameters": [
+          {
+            "name": "contractId",
+            "in": "path",
+            "description": "Required. System contract ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContractDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContractDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContractDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/contracts/customer/{customerId}": {
+      "get": {
+        "tags": [
+          "Contract"
+        ],
+        "summary": "Find contracts for specified customer",
+        "description": "Returns a list of contracts. Requires the customer ID.",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "description": "Required - System customer ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index, based on items per page (default is 1)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContractDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContractDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContractDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customers": {
+      "get": {
+        "tags": [
+          "Customer"
+        ],
+        "summary": "Find Customers",
+        "description": "Returns a list of customers.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index, based on items per page (default is 1)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "FromLastModifiedDate",
+            "in": "query",
+            "description": "Optional - Last modified date/time, interpreted in the account's configured timezone (no timezone offset allowed; format: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss, e.g., 2025-01-01 or 2025-01-01T08:30:00). Returns all customers modified on or after this date.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "SortBy",
+            "in": "query",
+            "description": "Optional - Sort order. Default is by Creation (CustomerId).",
+            "schema": {
+              "$ref": "#/components/schemas/CustomerSortBy"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomerDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomerDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomerDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Customer"
+        ],
+        "summary": "Create Customer",
+        "description": "Creates a new customer. Requires the customer name.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCustomerRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCustomerRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCustomerRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customers/{customerId}": {
+      "get": {
+        "tags": [
+          "Customer"
+        ],
+        "summary": "Find specified customer",
+        "description": "Returns a specified customer. Requires the customer ID.",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "description": "Required",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomerDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomerDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomerDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Customer"
+        ],
+        "summary": "Update specified customer",
+        "description": "Updates an existing customer. Requires the customer ID.\n\n\n \nThe following fields are editable:\n\n\n \nCustomer Name (CustomerName)\n\n\nBusiness Number (BusinessNumber)\n\n \nDomain (Domain)\n\n\nAddress (Address)\n\n\nCity (City)\n\n\nState (State)\n\n\nCountry (Country)\n\n\nPhone (Phone)\n\n\nFax (Fax)\n\n\nNotes (Notes)\n\n\nLinks (Links)\n\n\nLongitude (Longitude)\n\n\nLatitude (Latitude)\n\n\nZip Code (ZipCodeStr)",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "description": "Required",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCustomerRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCustomerRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCustomerRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Customer"
+        ],
+        "summary": "Update specified customer",
+        "description": "Updates an existing customer. Requires the customer ID.\n\n\n \nThe following fields are editable:\n\n\n \nCustomer Name (CustomerName)\n\n\nBusiness Number (BusinessNumber)\n\n \nDomain (Domain)\n\n\nAddress (Address)\n\n\nCity (City)\n\n\nState (State)\n\n\nCountry (Country)\n\n\nPhone (Phone)\n\n\nFax (Fax)\n\n\nNotes (Notes)\n\n\nLinks (Links)\n\n\nLongitude (Longitude)\n\n\nLatitude (Latitude)\n\n\nZip Code (ZipCodeStr)",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "description": "Required",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCustomerRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCustomerRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCustomerRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Customer"
+        ],
+        "summary": "Delete specified customer",
+        "description": "Deletes a specified customer. Requires the customer ID.",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "description": "Required",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customers/folders": {
+      "post": {
+        "tags": [
+          "Customer"
+        ],
+        "summary": "Create Customer Folder",
+        "description": "Requires the folder name and customer ID.\nThreshold profile ID is optional; if not included, the folder will inherit the threshold profile applied to the customer, if applicable.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFolderRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFolderRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFolderRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customers/attachments": {
+      "post": {
+        "tags": [
+          "Customer"
+        ],
+        "summary": "Create Customer Attachment",
+        "description": "Requires the customer ID and attachment name, including the file extension. Requires attachment to be represented in Base64 encoding.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCustomerAttachmentRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCustomerAttachmentRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCustomerAttachmentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/{customValueId}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find custom field value",
+        "description": "Returns a custom field value. Requires a custom value ID.",
+        "parameters": [
+          {
+            "name": "customValueId",
+            "in": "path",
+            "description": "Required - Custom Value ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/ticketfield/{ticketId}/{fieldName}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find custom field value for specified ticket",
+        "description": "Returns a custom field value for a specified ticket. Requires a ticket ID and a custom field name.",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set custom field value for specified Ticket",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set custom field value for specified Ticket",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/ticketfields/{ticketId}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find all custom field values for specified ticket",
+        "description": "Returns all custom field values for a specified ticket. Requires a ticket ID.",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/customerfield/{customerId}/{fieldName}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find custom field value for specified customer",
+        "description": "Returns a custom field value for a specified customer. Requires a customer ID and custom field name.",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "description": "Required - System Customer ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified Customer",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "description": "Required - System Customer id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified Customer",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "description": "Required - System Customer id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/customerfields/{customerId}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find all custom field values for specified customer",
+        "description": "Returns all custom field values for a specified customer. Requires a customer ID.",
+        "parameters": [
+          {
+            "name": "customerId",
+            "in": "path",
+            "description": "Required - System Customer ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/contactfield/{contactId}/{fieldName}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find custom field value for specified contact",
+        "description": "Returns a custom field value for a specified contact. Requires the contact ID and custom field name.",
+        "parameters": [
+          {
+            "name": "contactId",
+            "in": "path",
+            "description": "Required - System Contact ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified Contact",
+        "parameters": [
+          {
+            "name": "contactId",
+            "in": "path",
+            "description": "Required - System Contact id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified Contact",
+        "parameters": [
+          {
+            "name": "contactId",
+            "in": "path",
+            "description": "Required - System Contact id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/contactfields/{contactId}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find all custom field values for specified contact",
+        "description": "Returns all custom field values for a specified contact. Requires a contact ID.",
+        "parameters": [
+          {
+            "name": "contactId",
+            "in": "path",
+            "description": "Required - System Contact ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/contractfield/{contractId}/{fieldName}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find custom field value for specified contract",
+        "description": "Returns a custom field value for a specified contract. Requires the contract ID and custom field name.",
+        "parameters": [
+          {
+            "name": "contractId",
+            "in": "path",
+            "description": "Required - System contract ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified Contract",
+        "parameters": [
+          {
+            "name": "contractId",
+            "in": "path",
+            "description": "Required - System contract id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified Contract",
+        "parameters": [
+          {
+            "name": "contractId",
+            "in": "path",
+            "description": "Required - System contract id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/contractfields/{contractId}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find all custom field values for specified contract",
+        "description": "Returns all custom field values for a specified contract. Requires a contract ID.",
+        "parameters": [
+          {
+            "name": "contractId",
+            "in": "path",
+            "description": "Required - System contract ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/slafield/{slaId}/{fieldName}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find custom field value for specified SLA",
+        "description": "Returns a custom field value for a specified SLA. Requires the SLA ID and custom field name.",
+        "parameters": [
+          {
+            "name": "slaId",
+            "in": "path",
+            "description": "Required - System SLA ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified SLA",
+        "parameters": [
+          {
+            "name": "slaId",
+            "in": "path",
+            "description": "Required - System SLA id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified SLA",
+        "parameters": [
+          {
+            "name": "slaId",
+            "in": "path",
+            "description": "Required - System SLA id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/slafields/{slaId}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find all custom field values for specified SLA",
+        "description": "Returns all custom field values for a specified SLA. Requires an SLA ID.",
+        "parameters": [
+          {
+            "name": "slaId",
+            "in": "path",
+            "description": "Required - System SLA ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/agentfield/{agentId}/{fieldName}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find custom field value for specified agent",
+        "description": "Returns a custom field value for a specified agent. Requires the agent ID and custom field name.",
+        "parameters": [
+          {
+            "name": "agentId",
+            "in": "path",
+            "description": "Required - System Agent ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified Agent",
+        "parameters": [
+          {
+            "name": "agentId",
+            "in": "path",
+            "description": "Required - System Agent id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified Agent",
+        "parameters": [
+          {
+            "name": "agentId",
+            "in": "path",
+            "description": "Required - System Agent id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/agentfields/{agentId}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find all custom field values for specified agent",
+        "description": "Returns all custom field values for a specified agent. Requires an agent ID.",
+        "parameters": [
+          {
+            "name": "agentId",
+            "in": "path",
+            "description": "Required - System Agent ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/snmpfield/{snmpDeviceId}/{fieldName}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find custom field value for specified SNMP",
+        "description": "Returns a custom field value for a specified SNMP. Requires the SNMP ID and custom field name.",
+        "parameters": [
+          {
+            "name": "snmpDeviceId",
+            "in": "path",
+            "description": "Required - System SNMP ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified SNMP",
+        "parameters": [
+          {
+            "name": "snmpDeviceId",
+            "in": "path",
+            "description": "Required - System SNMP id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified SNMP",
+        "parameters": [
+          {
+            "name": "snmpDeviceId",
+            "in": "path",
+            "description": "Required - System SNMP id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/snmpfields/{snmpDeviceId}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find all custom field values for specified SNMP device",
+        "description": "Returns all custom field values for a specified SNMP device. Requires an SNMP device ID.",
+        "parameters": [
+          {
+            "name": "snmpDeviceId",
+            "in": "path",
+            "description": "Required - System SNMP ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/tcpfield/{tcpDeviceId}/{fieldName}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find custom field value for specified TCP",
+        "description": "Returns a custom field value for a specified TCP. Requires the TCP ID and custom field name.",
+        "parameters": [
+          {
+            "name": "tcpDeviceId",
+            "in": "path",
+            "description": "Required - System TCP ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified TCP",
+        "parameters": [
+          {
+            "name": "tcpDeviceId",
+            "in": "path",
+            "description": "Required - System TCP id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified TCP",
+        "parameters": [
+          {
+            "name": "tcpDeviceId",
+            "in": "path",
+            "description": "Required - System TCP id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/tcpfields/{tcpDeviceId}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find all custom field values for specified TCP device",
+        "description": "Returns all custom field values for a specified TCP device. Requires a TCP device ID.",
+        "parameters": [
+          {
+            "name": "tcpDeviceId",
+            "in": "path",
+            "description": "Required - System TCP ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/httpfield/{httpDeviceId}/{fieldName}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find custom field value for specified HTTP",
+        "description": "Returns a custom field value for a specified HTTP. Requires the HTTP ID and custom field name.",
+        "parameters": [
+          {
+            "name": "httpDeviceId",
+            "in": "path",
+            "description": "Required - System HTTP ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified HTTP",
+        "parameters": [
+          {
+            "name": "httpDeviceId",
+            "in": "path",
+            "description": "Required - System HTTP id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified HTTP",
+        "parameters": [
+          {
+            "name": "httpDeviceId",
+            "in": "path",
+            "description": "Required - System HTTP id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/httpfields/{httpDeviceId}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find all custom field values for specified HTTP device",
+        "description": "Returns all custom field values for a specified HTTP device. Requires an HTTP device ID.",
+        "parameters": [
+          {
+            "name": "httpDeviceId",
+            "in": "path",
+            "description": "Required - System HTTP ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/genericfield/{genericDeviceId}/{fieldName}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find custom field value for specified generic",
+        "description": "Returns a custom field value for a specified generic. Requires the generic ID and custom field name.",
+        "parameters": [
+          {
+            "name": "genericDeviceId",
+            "in": "path",
+            "description": "Required - System Generic ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified Generic",
+        "parameters": [
+          {
+            "name": "genericDeviceId",
+            "in": "path",
+            "description": "Required - System Generic id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Set value of custom field for specified Generic",
+        "parameters": [
+          {
+            "name": "genericDeviceId",
+            "in": "path",
+            "description": "Required - System Generic id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "description": "Required - System Custom field name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - System custom value to set",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCustomValueRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/genericfields/{genericDeviceId}": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Find all custom field values for specified generic device",
+        "description": "Returns all custom field values for a specified generic device. Requires a generic device ID.",
+        "parameters": [
+          {
+            "name": "genericDeviceId",
+            "in": "path",
+            "description": "Required - System Generic ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomValueDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/customvalues/customfields": {
+      "get": {
+        "tags": [
+          "CustomValues"
+        ],
+        "summary": "Get list of custom field and value options",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomFieldDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomFieldDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomFieldDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/departments": {
+      "get": {
+        "tags": [
+          "Department"
+        ],
+        "summary": "Find Department",
+        "description": "Returns a list of departments.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index, based on items per page (default is 1)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DepartmentDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DepartmentDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DepartmentDtoPagedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Department"
+        ],
+        "summary": "Create Department",
+        "description": "Creates a new department. Requires the department name.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDepartmentRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDepartmentRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDepartmentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/departments/{departmentId}": {
+      "get": {
+        "tags": [
+          "Department"
+        ],
+        "summary": "Find specified department",
+        "description": "Returns a specified department. Requires the department ID.",
+        "parameters": [
+          {
+            "name": "departmentId",
+            "in": "path",
+            "description": "Required",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DepartmentDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DepartmentDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DepartmentDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Department"
+        ],
+        "summary": "Update specified department",
+        "description": "Updates an existing department. Requires the department ID.\n\n\n \nThe following fields are editable:\n\n\n \nName: the name of the department\n\n\nDescription: a shor desciption of the department",
+        "parameters": [
+          {
+            "name": "departmentId",
+            "in": "path",
+            "description": "Required",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDepartmentRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDepartmentRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDepartmentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Department"
+        ],
+        "summary": "Update specified department",
+        "description": "Updates an existing department. Requires the department ID.\n\n\n \nThe following fields are editable:\n\n\n \nName: the name of the department\n\n\nDescription: a shor desciption of the department",
+        "parameters": [
+          {
+            "name": "departmentId",
+            "in": "path",
+            "description": "Required",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDepartmentRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDepartmentRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDepartmentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Department"
+        ],
+        "summary": "Delete specified department",
+        "description": "Deletes a specified department. Requires the department ID.",
+        "parameters": [
+          {
+            "name": "departmentId",
+            "in": "path",
+            "description": "Required",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/devices/genericdevices": {
+      "get": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Find Generic devices",
+        "description": "Returns a list of Generic devices.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index (default is 1), based on items per page",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "customerId",
+            "in": "query",
+            "description": "Optional - Customer ID (default is NULL)",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "monitoringAgentId",
+            "in": "query",
+            "description": "Optional - Monitoring Agent ID (default is NULL)",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericDeviceDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericDeviceDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericDeviceDtoPagedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/devices/genericdevice/{deviceId}": {
+      "get": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Find specified Generic device",
+        "description": "Returns a Generic device. Requires the device ID.",
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "description": "Required - System Device ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericDeviceDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericDeviceDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericDeviceDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Delete specified Generic device",
+        "description": "Deletes a Generic device. Requires the device ID.",
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "description": "Required - System Device ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/devices/genericdevice": {
+      "post": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Create Generic device",
+        "description": "Returns device ID and Device Guid.",
+        "requestBody": {
+          "description": "Required - new device params",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateGenericDeviceRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateGenericDeviceRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateGenericDeviceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedDeviceResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedDeviceResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedDeviceResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/devices/tcpdevices": {
+      "get": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Find TCP devices",
+        "description": "Returns a list of TCP devices.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index (default is 1), based on items per page",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "customerId",
+            "in": "query",
+            "description": "Optional - Customer ID (default is NULL)",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "monitoringAgentId",
+            "in": "query",
+            "description": "Optional - Monitoring Agent ID (default is NULL)",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TcpDeviceDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TcpDeviceDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TcpDeviceDtoPagedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/devices/tcpdevice/{deviceId}": {
+      "get": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Find specified TCP device",
+        "description": "Returns a TCP device. Requires the device ID.",
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "description": "Required - System Device ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TcpDeviceDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TcpDeviceDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TcpDeviceDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Delete specified TCP device",
+        "description": "Deletes a TCP device. Requires the device ID.",
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "description": "Required - System Device ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/devices/tcpdevice": {
+      "post": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Create TCP device",
+        "description": "Returns device ID and Device Guid.",
+        "requestBody": {
+          "description": "Required - new device params",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTcpDeviceRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTcpDeviceRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTcpDeviceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedDeviceResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedDeviceResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedDeviceResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/devices/httpdevices": {
+      "get": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Find HTTP devices",
+        "description": "Returns a list of HTTP devices.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index (default is 1), based on items per page",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "customerId",
+            "in": "query",
+            "description": "Optional - Customer ID (default is NULL)",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "monitoringAgentId",
+            "in": "query",
+            "description": "Optional - Monitoring Agent ID (default is NULL)",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpDeviceDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpDeviceDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpDeviceDtoPagedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/devices/httpdevice/{deviceId}": {
+      "get": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Find specified HTTP device",
+        "description": "Returns an HTTP device. Requires the device ID.",
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "description": "Required - System Device ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpDeviceDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpDeviceDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpDeviceDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Delete specified HTTP device",
+        "description": "Deletes an HTTP device. Requires the device ID.",
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "description": "Required - System Device ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/devices/httpdevice": {
+      "post": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Create HTTP device",
+        "description": "Returns device ID and Device Guid.",
+        "requestBody": {
+          "description": "Required - new device params",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateHttpDeviceRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateHttpDeviceRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateHttpDeviceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedDeviceResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedDeviceResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedDeviceResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/devices/snmpdevices": {
+      "get": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Find SNMP devices",
+        "description": "Returns a list of SNMP devices.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index (default is 1), based on items per page",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "customerId",
+            "in": "query",
+            "description": "Optional - Customer ID (default is NULL)",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "monitoringAgentId",
+            "in": "query",
+            "description": "Optional - Monitoring Agent ID (default is NULL)",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnmpDeviceDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnmpDeviceDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnmpDeviceDtoPagedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/devices/snmpdevice/{deviceId}": {
+      "get": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Find specified SNMP device",
+        "description": "Returns an SNMP device. Requires the device ID.",
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "description": "Required - System Device ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnmpDeviceDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnmpDeviceDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnmpDeviceDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Delete specified SNMP device",
+        "description": "Deletes an SNMP device. Requires the device ID.",
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "description": "Required - System Device ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/devices/snmpdevice/guid/{deviceGuid}": {
+      "get": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Find specified SNMP device by Device GUID",
+        "description": "Returns an SNMP device. Requires the device GUID.",
+        "parameters": [
+          {
+            "name": "deviceGuid",
+            "in": "path",
+            "description": "Required - System Device GUID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnmpDeviceDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnmpDeviceDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnmpDeviceDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/devices/snmpdevice/v1v2": {
+      "post": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Create SNMP device V1/V2",
+        "description": "Returns device ID and Device Guid.",
+        "requestBody": {
+          "description": "Required - new device params",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSnmpV1DeviceRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSnmpV1DeviceRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSnmpV1DeviceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedDeviceResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedDeviceResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedDeviceResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/devices/snmpdevice/v3": {
+      "post": {
+        "tags": [
+          "Device"
+        ],
+        "summary": "Create SNMP device V3",
+        "description": "Returns device ID and Device Guid.",
+        "requestBody": {
+          "description": "Required - new device params",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSnmpV3DeviceRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSnmpV3DeviceRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSnmpV3DeviceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedDeviceResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedDeviceResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedDeviceResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/knowledgebases": {
+      "get": {
+        "tags": [
+          "KnowledgeBase"
+        ],
+        "summary": "Find articles",
+        "description": "Returns a list of articles.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index (default is 1), based on items per page",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgeBaseDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgeBaseDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgeBaseDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/rates/products": {
+      "get": {
+        "tags": [
+          "Rate"
+        ],
+        "summary": "Find products",
+        "description": "Returns a list of products.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index, based on items per page (default is 1)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Rate"
+        ],
+        "summary": "Create product",
+        "description": "Creates a new product. Requires a product description.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRateRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRateRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/rates/products/{productId}": {
+      "get": {
+        "tags": [
+          "Rate"
+        ],
+        "summary": "Find specified product",
+        "description": "Returns a specified product. Requires the product ID.",
+        "parameters": [
+          {
+            "name": "productId",
+            "in": "path",
+            "description": "Required - System product ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Rate"
+        ],
+        "summary": "Update specified product",
+        "description": "Updates a specified product. Requires the product ID.\n\n\n \nThe following fields are editable:\n\n\n \nDescription\n\n\nCategory\n\n \nAmount\n\n\nSKU\n\n\nArchived",
+        "parameters": [
+          {
+            "name": "productId",
+            "in": "path",
+            "description": "Required - System Product ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRateRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRateRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Rate"
+        ],
+        "summary": "Delete specified product",
+        "description": "Deletes a specified product. Requires the product ID.",
+        "parameters": [
+          {
+            "name": "productId",
+            "in": "path",
+            "description": "Required - System Product ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/rates/expenses": {
+      "get": {
+        "tags": [
+          "Rate"
+        ],
+        "summary": "Find expenses",
+        "description": "Returns a list of expenses.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index, based on items per page (default is 1)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Rate"
+        ],
+        "summary": "Create expense",
+        "description": "Creates a new expense. Requires an expense description.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRateRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRateRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/rates/expenses/{expenseId}": {
+      "get": {
+        "tags": [
+          "Rate"
+        ],
+        "summary": "Find specified expense",
+        "description": "Returns a specified expense. Requires the expense ID.",
+        "parameters": [
+          {
+            "name": "expenseId",
+            "in": "path",
+            "description": "Required - System expense ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Rate"
+        ],
+        "summary": "Update specified expense",
+        "description": "Updates a specified expense. Requires the expense ID.\n\n\n \nThe following fields are editable:\n\n\n \nDescription\n\n\nCategory\n\n \nAmount\n\n\nSKU\n\n\nArchived",
+        "parameters": [
+          {
+            "name": "expenseId",
+            "in": "path",
+            "description": "Required - System Expense ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRateRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRateRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Rate"
+        ],
+        "summary": "Delete specified expense",
+        "description": "Deletes a specified expense. Requires the expense ID.",
+        "parameters": [
+          {
+            "name": "expenseId",
+            "in": "path",
+            "description": "Required - System Expense ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/tickets": {
+      "get": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Find tickets",
+        "description": "Returns a list of tickets.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index (default is 1), based on items per page",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "customerId",
+            "in": "query",
+            "description": "Optional - Filter by customer ID",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "ticketStatus",
+            "in": "query",
+            "description": "Optional - Filter by ticket status",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeRelations",
+            "in": "query",
+            "description": "Optional - Include RelationType and RelatedTicketId fields (default is false)",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Create ticket",
+        "description": "Creates a new ticket. Requires the enduser contact ID, title, and description.\n\n\n \nIf you wish to create a new enduser for the ticket then you need to provide:\n\n\n \nContact first name (EndUserFirstName)\n\n \nContact last name (EndUserLastName)\n\n \nEmail (EndUserEmail)",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTicketModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTicketModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTicketModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/tickets/noComments": {
+      "get": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Find tickets without comments",
+        "description": "Returns a list of tickets without comments.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index (default is 1), based on items per page",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "customerId",
+            "in": "query",
+            "description": "Optional - Filter by customer ID",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "ticketStatus",
+            "in": "query",
+            "description": "Optional - Filter by ticket status",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeRelations",
+            "in": "query",
+            "description": "Optional - Include RelationType and RelatedTicketId fields (default is false)",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/tickets/statusmodified": {
+      "get": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Find resolved and closed tickets",
+        "description": "Returns a list of resolved and closed tickets.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index (default is 1), based on items per page",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "includeComments",
+            "in": "query",
+            "description": "Optional - Include FirstComment, LastEndUserComment, LastTechnicianComment (default is true)",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "includeRelations",
+            "in": "query",
+            "description": "Optional - Include RelationType and RelatedTicketId fields (default is false)",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/tickets/lastmodified": {
+      "get": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Find modified tickets",
+        "description": "Returns a list of modified tickets.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index (default is 1), based on items per page",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "description": "Optional - Ticket's last modified date in UTC (default is today. Recommended format ISO 8601)",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "includeComments",
+            "in": "query",
+            "description": "Optional - Include the ticket's last comments (default is false)",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "includeRelations",
+            "in": "query",
+            "description": "Optional - Include RelationType and RelatedTicketId fields (default is false)",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/tickets/{ticketId}": {
+      "get": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Find specified ticket",
+        "description": "Returns the specified ticket. Requires the ticket ID.",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "includeRelations",
+            "in": "query",
+            "description": "Optional - Include RelationType and RelatedTicketId fields (default is false)",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Update specified ticket",
+        "description": "Updates an existing ticket. Requires the ticket ID.\n\n\n \nThe following fields are editable:\n\n\n \nTicket Title (TicketTitle)\n\n\nTicket Status (TicketStatus)\n\n \nTicket Type (TicketType)\n\n\nTicket Priority (TicketPriority)\n\n\nTicket Impact (TicketImpact)\n\n\nAssigned Technician ID (TechnicianContactID)",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTicketModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTicketModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTicketModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Update specified ticket",
+        "description": "Updates an existing ticket. Requires the ticket ID.\n\n\n \nThe following fields are editable:\n\n\n \nTicket Title (TicketTitle)\n\n\nTicket Status (TicketStatus)\n\n \nTicket Type (TicketType)\n\n\nTicket Priority (TicketPriority)\n\n\nTicket Impact (TicketImpact)\n\n\nAssigned Technician ID (TechnicianContactID)",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTicketModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTicketModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTicketModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Delete specified ticket",
+        "description": "Deletes the specified ticket. Requires the ticket ID.",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/tickets/{ticketId}/comments": {
+      "get": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Find ticket comments list",
+        "description": "Returns the ticket comments. Requires the ticket ID.",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index (default is 1), based on items per page",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketCommentDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketCommentDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketCommentDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Add comment to specified ticket",
+        "description": "Creates a new comment. Requires comment text and (TechnicianCommentDetails object or EnduserCommentDetails object) and optionally the comment Timestamp in UTC.\n\n\n \nIf you wish to create a new contact comment for the ticket then you need to provide:\n\n\n \nEnduserCommentDetails object with existing enduser contact ID\n\n\n \nIf you wish to create a new technicain internal comment for the ticket then you need to provide:\n\n\n \nTechnicianCommentDetails object with existing technician ID, and IsInternal set to true\n\n\n \nIf you wish to create a new technicain comment for the ticket then you need to provide:\n\n\n \nTechnicianCommentDetails object with existing technician ID, and IsInternal set to false",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddCommentToTicketModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddCommentToTicketModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddCommentToTicketModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/tickets/{ticketId}/attachments": {
+      "get": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Find specified ticket (attachments)",
+        "description": "Returns the specified ticket's attachments as urls. Requires the ticket ID.",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/tickets/{ticketId}/billableduration": {
+      "get": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Find specified ticket (billable duration)",
+        "description": "Returns the specified ticket (billable duration). Requires the ticket ID.",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDurationsDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDurationsDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDurationsDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/tickets/billableduration": {
+      "post": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Find tickets (billable duration)",
+        "description": "Returns the tickets (billable duration). Requires the ticket ID's.",
+        "requestBody": {
+          "description": "Required - List of Ticket IDs (up to 50)",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TicketDurationsDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TicketDurationsDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TicketDurationsDto"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/tickets/{ticketId}/nonbillableduration": {
+      "get": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Find specified ticket (non-billable duration)",
+        "description": "Returns the specified ticket (non-billable duration). Requires the ticket ID.",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDurationsDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDurationsDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDurationsDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/tickets/{ticketId}/workhours": {
+      "get": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Find specified ticket (workhours duration)",
+        "description": "Returns a record of the specified ticket's billable and non-billable workhours. Requires the ticket ID.",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketWorkHoursSummaryDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketWorkHoursSummaryDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketWorkHoursSummaryDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Ticket"
+        ],
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWorkHoursModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWorkHoursModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWorkHoursModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/tickets/billableworkhourssiteduration": {
+      "post": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Summary billable work hours duration by on customer site and off customer site",
+        "description": "Returns a summary of the specified tickets on-site and off-site workhours duration",
+        "requestBody": {
+          "description": "Required - List of Ticket IDs (up to 50)",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int64"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketsWorkHoursSiteDurationSummaryDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketsWorkHoursSiteDurationSummaryDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketsWorkHoursSiteDurationSummaryDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/tickets/{ticketId}/workhoursrecords": {
+      "get": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Find tickets (workhour list)",
+        "description": "Returns the ticket's workhours. Requires the ticket ID.",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index (default is 1), based on items per page",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketWorkHoursDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketWorkHoursDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketWorkHoursDtoPagedResult"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/tickets/{ticketId}/relations": {
+      "post": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Add relation to specified ticket",
+        "description": "Links two tickets with a parent/child relation. Specify the ID of the ticket to link from, the related ticket ID, and the relation type (Parent or Child).",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Required - Related ticket ID and relation type",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddTicketRelationModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddTicketRelationModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddTicketRelationModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/tickets/{ticketId}/relations/{relationType}": {
+      "delete": {
+        "tags": [
+          "Ticket"
+        ],
+        "summary": "Remove relation from specified ticket",
+        "description": "Removes the parent or child relation from a ticket. Requires the ticket ID and the relation type to remove.",
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "description": "Required - System Ticket ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "relationType",
+            "in": "path",
+            "description": "Required - Relation type to remove (Parent or Child)",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RelationType"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/v3/workhours": {
+      "get": {
+        "tags": [
+          "Workhour"
+        ],
+        "summary": "Get workhour records",
+        "description": "Returns a list of workhour records with optional date filtering.",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Optional - Page index (default is 1), based on items per page",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "itemsInPage",
+            "in": "query",
+            "description": "Optional - Number of items per page (default is 20, max is 50)",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "startWorkhour",
+            "in": "query",
+            "description": "Optional - Filter records with StartWorkHour on or after this date/time, interpreted in the account's configured timezone (no timezone offset allowed; format: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss, e.g., 2025-01-01 or 2025-01-01T08:30:00)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "endWorkhour",
+            "in": "query",
+            "description": "Optional - Filter records with EndWorkHour on or before this date/time, interpreted in the account's configured timezone (no timezone offset allowed; format: yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss, e.g., 2025-01-31 or 2025-01-31T17:00:00)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeRates",
+            "in": "query",
+            "description": "Optional - Include rate information (RateID and RateAmount) in the response (default is false)",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkhourRecordDtoPagedResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkhourRecordDtoPagedResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkhourRecordDtoPagedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid date format"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AccountInfoResponse": {
+        "type": "object",
+        "properties": {
+          "AccountID": {
+            "type": "string",
+            "nullable": true
+          },
+          "Country": {
+            "type": "string",
+            "nullable": true
+          },
+          "CompanyName": {
+            "type": "string",
+            "nullable": true
+          },
+          "CreatedOn": {
+            "type": "string",
+            "nullable": true
+          },
+          "State": {
+            "type": "string",
+            "nullable": true
+          },
+          "TimeZoneName": {
+            "type": "string",
+            "nullable": true
+          },
+          "City": {
+            "type": "string",
+            "nullable": true
+          },
+          "Address": {
+            "type": "string",
+            "nullable": true
+          },
+          "PostalCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "Phone": {
+            "type": "string",
+            "nullable": true
+          },
+          "IsITDepartment": {
+            "type": "boolean"
+          },
+          "Plan": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AddCommentToTicketModel": {
+        "type": "object",
+        "properties": {
+          "CommentText": {
+            "type": "string",
+            "nullable": true
+          },
+          "CommentTimestampUTC": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "TechnicianCommentDetails": {
+            "$ref": "#/components/schemas/TechnicianCommentDetails"
+          },
+          "EnduserCommentDetails": {
+            "$ref": "#/components/schemas/EnduserCommentDetails"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AddTicketRelationModel": {
+        "type": "object",
+        "properties": {
+          "RelatedTicketId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "RelationType": {
+            "$ref": "#/components/schemas/RelationType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AgentAvailableUpdateDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "class": {
+            "type": "string",
+            "nullable": true
+          },
+          "kbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AgentAvailableUpdatesResponse": {
+        "type": "object",
+        "properties": {
+          "deviceGuid": {
+            "type": "string",
+            "nullable": true
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "availableUpdates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentAvailableUpdateDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AgentDto": {
+        "type": "object",
+        "properties": {
+          "MachineID": {
+            "type": "string",
+            "nullable": true
+          },
+          "AgentID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "DeviceGuid": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "FolderID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "FolderName": {
+            "type": "string",
+            "nullable": true
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "CustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "AgentName": {
+            "type": "string",
+            "nullable": true
+          },
+          "SystemName": {
+            "type": "string",
+            "nullable": true
+          },
+          "MachineName": {
+            "type": "string",
+            "nullable": true
+          },
+          "DomainName": {
+            "type": "string",
+            "nullable": true
+          },
+          "CurrentLoggedUsers": {
+            "type": "string",
+            "nullable": true
+          },
+          "ComputerDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "Monitored": {
+            "type": "boolean"
+          },
+          "AgentVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "Favorite": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "ThresholdID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "MonitoredAgentID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "Created": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "Modified": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "Online": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "LastSeen": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "ReportedFromIP": {
+            "type": "string",
+            "nullable": true
+          },
+          "AppViewUrl": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "Motherboard": {
+            "type": "string",
+            "nullable": true
+          },
+          "Processor": {
+            "type": "string",
+            "nullable": true
+          },
+          "Memory": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "Display": {
+            "type": "string",
+            "nullable": true
+          },
+          "Sound": {
+            "type": "string",
+            "nullable": true
+          },
+          "ProcessorCoresCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "SystemDrive": {
+            "type": "string",
+            "nullable": true
+          },
+          "ProcessorClock": {
+            "type": "string",
+            "nullable": true
+          },
+          "Vendor": {
+            "type": "string",
+            "nullable": true
+          },
+          "VendorSerialNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "VendorBrandModel": {
+            "type": "string",
+            "nullable": true
+          },
+          "ProductName": {
+            "type": "string",
+            "nullable": true
+          },
+          "BiosManufacturer": {
+            "type": "string",
+            "nullable": true
+          },
+          "BiosVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "BiosReleaseDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "MacAddresses": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "IpAddresses": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "HardwareDisks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HardwareDiskDto"
+            },
+            "nullable": true
+          },
+          "BatteryInfo": {
+            "$ref": "#/components/schemas/BatteryDto"
+          },
+          "OS": {
+            "type": "string",
+            "nullable": true
+          },
+          "OSType": {
+            "type": "string",
+            "nullable": true
+          },
+          "WindowsSerialNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "Office": {
+            "type": "string",
+            "nullable": true
+          },
+          "OfficeSP": {
+            "type": "string",
+            "nullable": true
+          },
+          "OfficeOEM": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "OfficeSerialNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "OSNum": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "LastRebootTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "OSVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "OSBuild": {
+            "type": "string",
+            "nullable": true
+          },
+          "OfficeFullVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "LastLoginUser": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "DeviceType": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AgentDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AgentInstalledUpdateDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "class": {
+            "type": "string",
+            "nullable": true
+          },
+          "kbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "installDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AgentInstalledUpdatesResponse": {
+        "type": "object",
+        "properties": {
+          "deviceGuid": {
+            "type": "string",
+            "nullable": true
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "installedUpdates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentInstalledUpdateDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AlertCategory": {
+        "enum": [
+          "Hardware",
+          "Disk",
+          "Availability",
+          "Performance",
+          "Exchange",
+          "General"
+        ],
+        "type": "string"
+      },
+      "AlertCategoryDto": {
+        "enum": [
+          "Hardware",
+          "Disk",
+          "Availability",
+          "Performance",
+          "Exchange",
+          "General"
+        ],
+        "type": "string"
+      },
+      "AlertDto": {
+        "type": "object",
+        "properties": {
+          "AlertID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "Code": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "Source": {
+            "type": "string",
+            "nullable": true
+          },
+          "Title": {
+            "type": "string",
+            "nullable": true
+          },
+          "Severity": {
+            "$ref": "#/components/schemas/AlertSeverity"
+          },
+          "Created": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "SnoozedEndDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "DeviceGuid": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "AgentId": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "AdditionalInfo": {
+            "type": "string",
+            "nullable": true
+          },
+          "Archived": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "AlertCategoryID": {
+            "$ref": "#/components/schemas/AlertCategory"
+          },
+          "ArchivedDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "TicketID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "AlertMessage": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "DeviceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "CustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "FolderID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "PollingCyclesCount": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "DeviceType": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AlertDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlertDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AlertSeverity": {
+        "enum": [
+          "Information",
+          "Warning",
+          "Critical"
+        ],
+        "type": "string"
+      },
+      "AlertSeverityDto": {
+        "enum": [
+          "Information",
+          "Warning",
+          "Critical"
+        ],
+        "type": "string"
+      },
+      "AlertStatus": {
+        "enum": [
+          "Open",
+          "Resolved",
+          "Snoozed"
+        ],
+        "type": "string"
+      },
+      "Authentication": {
+        "enum": [
+          "Undefined",
+          "SHA1",
+          "MD5"
+        ],
+        "type": "string"
+      },
+      "BatteryDto": {
+        "type": "object",
+        "properties": {
+          "Id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "BatteryHealth": {
+            "type": "number",
+            "format": "double",
+            "readOnly": true
+          },
+          "DesignedCapacity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "FullChargeCapacity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "CycleCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BlockHoursContractDto": {
+        "type": "object",
+        "properties": {
+          "HoursIncluded": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "PricePerHour": {
+            "$ref": "#/components/schemas/RateDto"
+          },
+          "OverageRate": {
+            "$ref": "#/components/schemas/RateDto"
+          },
+          "CommitRollover": {
+            "type": "boolean"
+          },
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BlockMoneyContractDto": {
+        "type": "object",
+        "properties": {
+          "Amount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "ContractAmount": {
+            "$ref": "#/components/schemas/RateDto"
+          },
+          "PrimaryRate": {
+            "$ref": "#/components/schemas/RateDto"
+          },
+          "AdditionalRates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RateDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "CommitRollover": {
+            "type": "boolean"
+          },
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContactDto": {
+        "type": "object",
+        "properties": {
+          "EndUserID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "CustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "Firstname": {
+            "type": "string",
+            "nullable": true
+          },
+          "Lastname": {
+            "type": "string",
+            "nullable": true
+          },
+          "JobTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "Email": {
+            "type": "string",
+            "nullable": true
+          },
+          "Phone": {
+            "type": "string",
+            "nullable": true
+          },
+          "MobilePhone": {
+            "type": "string",
+            "nullable": true
+          },
+          "IsContactPerson": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "InIgnoreMode": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "CreatedOn": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "LastModified": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "Archived": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "DepartmentID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "DepartmentName": {
+            "type": "string",
+            "nullable": true
+          },
+          "DefaultAgentId": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContactDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContactSortBy": {
+        "enum": [
+          "Creation",
+          "LastModified"
+        ],
+        "type": "string"
+      },
+      "ContractBillingPeriodOptions": {
+        "enum": [
+          "EndOfContractDuration",
+          "Weekly",
+          "BiWeekly",
+          "Monthly",
+          "Quarterly",
+          "TwiceAYear",
+          "Yearly",
+          "OnDemand"
+        ],
+        "type": "string"
+      },
+      "ContractDto": {
+        "type": "object",
+        "properties": {
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "CustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "ContractID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "ContractName": {
+            "type": "string",
+            "nullable": true
+          },
+          "ContractType": {
+            "$ref": "#/components/schemas/ContractTypeOptions"
+          },
+          "Active": {
+            "type": "boolean"
+          },
+          "Default": {
+            "type": "boolean"
+          },
+          "Taxable": {
+            "type": "boolean"
+          },
+          "StartDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "EndDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "RetainerFlatFeeContract": {
+            "$ref": "#/components/schemas/RetainerFlatFeeContractDto"
+          },
+          "HourlyContract": {
+            "$ref": "#/components/schemas/HourlyContractDto"
+          },
+          "BlockHoursContract": {
+            "$ref": "#/components/schemas/BlockHoursContractDto"
+          },
+          "BlockMoneyContract": {
+            "$ref": "#/components/schemas/BlockMoneyContractDto"
+          },
+          "RemoteMonitoringContract": {
+            "$ref": "#/components/schemas/RemoteMonitoringContractDto"
+          },
+          "OnlineBackupContract": {
+            "$ref": "#/components/schemas/OnlineBackupContractDto"
+          },
+          "ProjectOneTimeFeeContract": {
+            "$ref": "#/components/schemas/ProjectOneTimeFeeContractDto"
+          },
+          "ProjectHourlyRateContract": {
+            "$ref": "#/components/schemas/ProjectHourlyRateContractDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContractDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContractDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContractMonitoredByOptions": {
+        "enum": [
+          "PCAgents",
+          "ServerAgents",
+          "OtherDevices",
+          "AgentsOnly",
+          "All",
+          "PCsTotalGB",
+          "ServersTotalGB",
+          "TotalGB",
+          "MacAgents"
+        ],
+        "type": "string"
+      },
+      "ContractTypeOptions": {
+        "enum": [
+          "RetainerFlatFee",
+          "BlockHours",
+          "Hourly",
+          "RemoteMonitoring",
+          "BlockMoney",
+          "ProjectOneTimeFee",
+          "ProjectHourlyRate",
+          "OnlineBackup"
+        ],
+        "type": "string"
+      },
+      "CreateAlertRequest": {
+        "type": "object",
+        "properties": {
+          "DeviceGuid": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "Title": {
+            "type": "string",
+            "nullable": true
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "Code": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "Severity": {
+            "$ref": "#/components/schemas/AlertSeverityDto"
+          },
+          "ThresholdValue1": {
+            "type": "string",
+            "nullable": true
+          },
+          "ThresholdValue2": {
+            "type": "string",
+            "nullable": true
+          },
+          "ThresholdValue3": {
+            "type": "string",
+            "nullable": true
+          },
+          "ThresholdValue4": {
+            "type": "string",
+            "nullable": true
+          },
+          "ThresholdValue5": {
+            "type": "string",
+            "nullable": true
+          },
+          "SnoozedEndDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "AdditionalInfo": {
+            "type": "string",
+            "nullable": true
+          },
+          "AlertCategoryID": {
+            "$ref": "#/components/schemas/AlertCategoryDto"
+          },
+          "TicketID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "MessageTemplate": {
+            "type": "string",
+            "nullable": true
+          },
+          "FolderID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateBlockHoursContractDto": {
+        "type": "object",
+        "properties": {
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          },
+          "HoursIncluded": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "CommitRollover": {
+            "type": "boolean"
+          },
+          "HourlyRateID": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "OverageRateID": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateBlockMoneyContractDto": {
+        "type": "object",
+        "properties": {
+          "ContractAmountRateID": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          },
+          "CommitRollover": {
+            "type": "boolean"
+          },
+          "HourlyRateID": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "OverageRateID": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateContactRequest": {
+        "required": [
+          "Email"
+        ],
+        "type": "object",
+        "properties": {
+          "Email": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "CustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "Firstname": {
+            "type": "string",
+            "nullable": true
+          },
+          "Lastname": {
+            "type": "string",
+            "nullable": true
+          },
+          "JobTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "Phone": {
+            "type": "string",
+            "nullable": true
+          },
+          "MobilePhone": {
+            "type": "string",
+            "nullable": true
+          },
+          "IsContactPerson": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "InIgnoreMode": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "CreatedOn": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "DepartmentID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "DepartmentName": {
+            "type": "string",
+            "nullable": true
+          },
+          "DefaultAgentId": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateContractDto": {
+        "type": "object",
+        "properties": {
+          "ContractName": {
+            "type": "string",
+            "nullable": true
+          },
+          "SLAId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Default": {
+            "type": "boolean"
+          },
+          "StartDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "EndDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "Active": {
+            "type": "boolean"
+          },
+          "Taxable": {
+            "type": "boolean"
+          },
+          "TaxId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "ContractType": {
+            "$ref": "#/components/schemas/ContractTypeOptions"
+          },
+          "Notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "RetainerFlatFeeContract": {
+            "$ref": "#/components/schemas/CreateRetainerFlatFeeContractDto"
+          },
+          "HourlyContract": {
+            "$ref": "#/components/schemas/CreateHourlyContractDto"
+          },
+          "BlockHoursContract": {
+            "$ref": "#/components/schemas/CreateBlockHoursContractDto"
+          },
+          "BlockMoneyContract": {
+            "$ref": "#/components/schemas/CreateBlockMoneyContractDto"
+          },
+          "RemoteMonitoringContract": {
+            "$ref": "#/components/schemas/CreateRemoteMonitoringContractDto"
+          },
+          "OnlineBackupContract": {
+            "$ref": "#/components/schemas/CreateOnlineBackupContractDto"
+          },
+          "ProjectOneTimeFeeContract": {
+            "$ref": "#/components/schemas/CreateProjectOneTimeFeeContractDto"
+          },
+          "ProjectHourlyRateContract": {
+            "$ref": "#/components/schemas/CreateProjectHourlyRateContractDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateCustomerAttachmentRequest": {
+        "type": "object",
+        "properties": {
+          "CustomerId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "ContentBased64": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateCustomerRequest": {
+        "type": "object",
+        "properties": {
+          "CustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "CreatedOn": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "BusinessNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "Domain": {
+            "type": "string",
+            "nullable": true
+          },
+          "Address": {
+            "type": "string",
+            "nullable": true
+          },
+          "City": {
+            "type": "string",
+            "nullable": true
+          },
+          "State": {
+            "type": "string",
+            "nullable": true
+          },
+          "Country": {
+            "type": "string",
+            "nullable": true
+          },
+          "Phone": {
+            "type": "string",
+            "nullable": true
+          },
+          "Fax": {
+            "type": "string",
+            "nullable": true
+          },
+          "Notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "Links": {
+            "type": "string",
+            "nullable": true
+          },
+          "Longitude": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "Latitude": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "ZipCodeStr": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateDepartmentRequest": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "Description": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateFolderRequest": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "CustomerId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "ThresholdId": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateGenericDeviceRequest": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "FolderID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "MonitoringAgentID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Monitored": {
+            "type": "boolean"
+          },
+          "Hostname": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateHourlyContractDto": {
+        "type": "object",
+        "properties": {
+          "HourlyRateID": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "AdditionalRateIDs": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateHttpDeviceRequest": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "FolderID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "MonitoringAgentID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Monitored": {
+            "type": "boolean"
+          },
+          "URL": {
+            "type": "string",
+            "nullable": true
+          },
+          "Pattern": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateOnlineBackupContractDto": {
+        "type": "object",
+        "properties": {
+          "CountBy": {
+            "$ref": "#/components/schemas/ContractMonitoredByOptions"
+          },
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          },
+          "PerGBRateID": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateProjectHourlyRateContractDto": {
+        "type": "object",
+        "properties": {
+          "TotalAmountRateId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "AdditionalRateIDs": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateProjectOneTimeFeeContractDto": {
+        "type": "object",
+        "properties": {
+          "TotalAmountRateId": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateRateRequest": {
+        "type": "object",
+        "properties": {
+          "Description": {
+            "type": "string",
+            "nullable": true
+          },
+          "Amount": {
+            "type": "number",
+            "format": "double"
+          },
+          "SKU": {
+            "type": "string",
+            "nullable": true
+          },
+          "Category": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateRemoteMonitoringContractDto": {
+        "type": "object",
+        "properties": {
+          "CountBy": {
+            "$ref": "#/components/schemas/ContractMonitoredByOptions"
+          },
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          },
+          "PerDeviceRateID": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateRetainerFlatFeeContractDto": {
+        "type": "object",
+        "properties": {
+          "RateID": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "Quantity": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateSnmpV1DeviceRequest": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "FolderID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "MonitoringAgentID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Monitored": {
+            "type": "boolean"
+          },
+          "Hostname": {
+            "type": "string",
+            "nullable": true
+          },
+          "Port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "SNMPType": {
+            "type": "string",
+            "nullable": true
+          },
+          "Community": {
+            "type": "string",
+            "nullable": true
+          },
+          "SNMPVersion": {
+            "$ref": "#/components/schemas/SnmpVersionOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateSnmpV3DeviceRequest": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "FolderID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "MonitoringAgentID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Monitored": {
+            "type": "boolean"
+          },
+          "Hostname": {
+            "type": "string",
+            "nullable": true
+          },
+          "Port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "SNMPType": {
+            "type": "string",
+            "nullable": true
+          },
+          "Username": {
+            "type": "string",
+            "nullable": true
+          },
+          "AuthenticationAlg": {
+            "$ref": "#/components/schemas/Authentication"
+          },
+          "PrivacyAlg": {
+            "$ref": "#/components/schemas/Privacy"
+          },
+          "AuthenticationPassword": {
+            "type": "string",
+            "nullable": true
+          },
+          "PrivacyPassword": {
+            "type": "string",
+            "nullable": true
+          },
+          "_SecurityLevel": {
+            "$ref": "#/components/schemas/SecurityLevel"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateTcpDeviceRequest": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "FolderID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "MonitoringAgentID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Monitored": {
+            "type": "boolean"
+          },
+          "Hostname": {
+            "type": "string",
+            "nullable": true
+          },
+          "Ports": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Port"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateTicketModel": {
+        "type": "object",
+        "properties": {
+          "TicketTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "Description": {
+            "type": "string",
+            "nullable": true
+          },
+          "TicketPriority": {
+            "$ref": "#/components/schemas/TicketPriorityOptions"
+          },
+          "TicketImpact": {
+            "$ref": "#/components/schemas/TicketsImpactOptions"
+          },
+          "TicketStatus": {
+            "type": "string",
+            "nullable": true
+          },
+          "TicketType": {
+            "$ref": "#/components/schemas/TicketTypesForAPI"
+          },
+          "EndUserID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "EndUserFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "EndUserLastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "EndUserEmail": {
+            "type": "string",
+            "nullable": true
+          },
+          "EndUserPhone": {
+            "type": "string",
+            "nullable": true
+          },
+          "TechnicianContactID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "TechnicianEmail": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateWorkHoursModel": {
+        "type": "object",
+        "properties": {
+          "StartWorkHour": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "EndWorkHour": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "TechnicianContactID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "TechnicianEmail": {
+            "type": "string",
+            "nullable": true
+          },
+          "Billiable": {
+            "type": "boolean"
+          },
+          "OnCustomerSite": {
+            "type": "boolean"
+          },
+          "Description": {
+            "type": "string",
+            "nullable": true
+          },
+          "RateID": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreatedDeviceResult": {
+        "type": "object",
+        "properties": {
+          "DeviceId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "DeviceGuid": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomFieldDataTypeDto": {
+        "enum": [
+          "Text",
+          "Boolean",
+          "Numeric",
+          "Date",
+          "Options",
+          "OptionsWithDependencies"
+        ],
+        "type": "string"
+      },
+      "CustomFieldDto": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "DataType": {
+            "$ref": "#/components/schemas/CustomFieldDataTypeDto"
+          },
+          "Target": {
+            "$ref": "#/components/schemas/CustomFieldTargetDto"
+          },
+          "PossibleValues": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OptionFieldValues"
+            },
+            "nullable": true
+          },
+          "ParentAttributeName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomFieldTargetDto": {
+        "enum": [
+          "Customer",
+          "Ticket",
+          "Contact",
+          "Contract",
+          "SLA",
+          "Agent",
+          "SNMPDevice",
+          "TCPDevice",
+          "HTTPDevice",
+          "GenericDevice"
+        ],
+        "type": "string"
+      },
+      "CustomValueDto": {
+        "type": "object",
+        "properties": {
+          "ItemId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "FieldName": {
+            "type": "string",
+            "nullable": true
+          },
+          "ValueAsString": {
+            "type": "string",
+            "nullable": true
+          },
+          "ValueAsDecimal": {
+            "type": "number",
+            "format": "double"
+          },
+          "ValueAsDateTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "ValueAsBool": {
+            "type": "boolean"
+          },
+          "OptionId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomerDto": {
+        "type": "object",
+        "properties": {
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "CustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "CreatedOn": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "LastModified": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "BusinessNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "Domain": {
+            "type": "string",
+            "nullable": true
+          },
+          "Address": {
+            "type": "string",
+            "nullable": true
+          },
+          "City": {
+            "type": "string",
+            "nullable": true
+          },
+          "State": {
+            "type": "string",
+            "nullable": true
+          },
+          "Country": {
+            "type": "string",
+            "nullable": true
+          },
+          "Phone": {
+            "type": "string",
+            "nullable": true
+          },
+          "Fax": {
+            "type": "string",
+            "nullable": true
+          },
+          "Notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "Logo": {
+            "type": "string",
+            "nullable": true
+          },
+          "Links": {
+            "type": "string",
+            "nullable": true
+          },
+          "Longitude": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "Latitude": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "ZipCodeStr": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomerDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomerDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomerSortBy": {
+        "enum": [
+          "Creation",
+          "LastModified"
+        ],
+        "type": "string"
+      },
+      "DepartmentDto": {
+        "type": "object",
+        "properties": {
+          "Id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "Description": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DepartmentDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DepartmentDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "EnduserCommentDetails": {
+        "type": "object",
+        "properties": {
+          "EnduserId": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GenericDeviceDto": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "DeviceID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "DeviceGuid": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "FolderID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "CustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "Monitored": {
+            "type": "boolean"
+          },
+          "MonitoringAgentID": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GenericDeviceDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GenericDeviceDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "HardwareDiskDto": {
+        "type": "object",
+        "properties": {
+          "Drive": {
+            "type": "string",
+            "nullable": true
+          },
+          "Free": {
+            "type": "number",
+            "format": "double"
+          },
+          "Used": {
+            "type": "number",
+            "format": "double"
+          },
+          "Total": {
+            "type": "number",
+            "format": "double",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "HourlyContractDto": {
+        "type": "object",
+        "properties": {
+          "PrimaryRate": {
+            "$ref": "#/components/schemas/RateDto"
+          },
+          "AdditionalRates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RateDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "HttpDeviceDto": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "DeviceID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "DeviceGuid": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "CustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "FolderID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "MonitoringAgentID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "URL": {
+            "type": "string",
+            "nullable": true
+          },
+          "Pattern": {
+            "type": "string",
+            "nullable": true
+          },
+          "URLUp": {
+            "type": "boolean"
+          },
+          "ContainsPattern": {
+            "type": "boolean"
+          },
+          "Monitored": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "HttpDeviceDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HttpDeviceDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "InvoiceContactDetailsDto": {
+        "type": "object",
+        "properties": {
+          "CompanyName": {
+            "type": "string",
+            "nullable": true
+          },
+          "ContactFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "ContactLastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "ContactFullName": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "Address": {
+            "type": "string",
+            "nullable": true
+          },
+          "State": {
+            "type": "string",
+            "nullable": true
+          },
+          "Country": {
+            "type": "string",
+            "nullable": true
+          },
+          "ZipCode": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "City": {
+            "type": "string",
+            "nullable": true
+          },
+          "Phone": {
+            "type": "string",
+            "nullable": true
+          },
+          "Email": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "InvoiceDto": {
+        "type": "object",
+        "properties": {
+          "IsAdhoc": {
+            "type": "boolean"
+          },
+          "InvoiceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "InvoiceNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "InvoiceNumberAsString": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "Total": {
+            "type": "number",
+            "format": "double",
+            "readOnly": true
+          },
+          "Subtotal": {
+            "type": "number",
+            "format": "double",
+            "readOnly": true
+          },
+          "Tax": {
+            "type": "number",
+            "format": "double",
+            "readOnly": true
+          },
+          "TaxPercentage": {
+            "type": "number",
+            "format": "double",
+            "nullable": true,
+            "readOnly": true
+          },
+          "InvoiceDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "ContractName": {
+            "type": "string",
+            "nullable": true
+          },
+          "PeriodStartDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "PeriodEndDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "Currency": {
+            "type": "string",
+            "nullable": true
+          },
+          "LineItems": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InvoiceLineItemDto"
+            },
+            "nullable": true
+          },
+          "From": {
+            "$ref": "#/components/schemas/InvoiceContactDetailsDto"
+          },
+          "To": {
+            "$ref": "#/components/schemas/InvoiceContactDetailsDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "InvoiceDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InvoiceDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "InvoiceLineItemDto": {
+        "type": "object",
+        "properties": {
+          "Product": {
+            "type": "string",
+            "nullable": true
+          },
+          "Description": {
+            "type": "string",
+            "nullable": true
+          },
+          "Quantity": {
+            "type": "number",
+            "format": "double"
+          },
+          "Rate": {
+            "type": "number",
+            "format": "double"
+          },
+          "TaxPercentage": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "DiscountPercentage": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "Total": {
+            "type": "number",
+            "format": "double",
+            "readOnly": true
+          },
+          "Subtotal": {
+            "type": "number",
+            "format": "double",
+            "readOnly": true
+          },
+          "Tax": {
+            "type": "number",
+            "format": "double",
+            "readOnly": true
+          },
+          "LineIdx": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "KnowledgeBaseDto": {
+        "type": "object",
+        "properties": {
+          "KBID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "KBTimestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "KBContext": {
+            "type": "string",
+            "nullable": true
+          },
+          "KBProduct": {
+            "type": "string",
+            "nullable": true
+          },
+          "KBRating_Yes": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "KBRating_No": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "KBRating_Views": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "KBLastModified": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "KBIsPrivate": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "KBStatus": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "KBPriority": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "KBKeywords": {
+            "type": "string",
+            "nullable": true
+          },
+          "KBAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "SectionId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "SectionName": {
+            "type": "string",
+            "nullable": true
+          },
+          "CategoryId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "CategoryName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "KnowledgeBaseDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/KnowledgeBaseDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "OnlineBackupContractDto": {
+        "type": "object",
+        "properties": {
+          "RatePerGB": {
+            "$ref": "#/components/schemas/RateDto"
+          },
+          "CountBy": {
+            "$ref": "#/components/schemas/ContractMonitoredByOptions"
+          },
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "OptionFieldValues": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string",
+            "nullable": true
+          },
+          "Text": {
+            "type": "string",
+            "nullable": true
+          },
+          "ParentName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Port": {
+        "type": "object",
+        "properties": {
+          "PortNum": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "Monitored": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PortDto": {
+        "type": "object",
+        "properties": {
+          "PortNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "Monitored": {
+            "type": "boolean"
+          },
+          "Available": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Privacy": {
+        "enum": [
+          "Undefined",
+          "AES",
+          "DES"
+        ],
+        "type": "string"
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": { }
+      },
+      "ProjectHourlyRateContractDto": {
+        "type": "object",
+        "properties": {
+          "PrimaryRate": {
+            "$ref": "#/components/schemas/RateDto"
+          },
+          "AdditionalRates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RateDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProjectOneTimeFeeContractDto": {
+        "type": "object",
+        "properties": {
+          "TotalAmount": {
+            "$ref": "#/components/schemas/RateDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RateDto": {
+        "type": "object",
+        "properties": {
+          "RateID": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "Amount": {
+            "type": "number",
+            "format": "double"
+          },
+          "Description": {
+            "type": "string",
+            "nullable": true
+          },
+          "SKU": {
+            "type": "string",
+            "nullable": true
+          },
+          "Category": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "RateDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RateDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "RelationType": {
+        "enum": [
+          "None",
+          "Parent",
+          "Child"
+        ],
+        "type": "string"
+      },
+      "RemoteMonitoringContractDto": {
+        "type": "object",
+        "properties": {
+          "RatePerDevice": {
+            "$ref": "#/components/schemas/RateDto"
+          },
+          "CountBy": {
+            "$ref": "#/components/schemas/ContractMonitoredByOptions"
+          },
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Result": {
+        "type": "object",
+        "properties": {
+          "ActionID": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "RetainerFlatFeeContractDto": {
+        "type": "object",
+        "properties": {
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          },
+          "Quantity": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "Rate": {
+            "$ref": "#/components/schemas/RateDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SecurityLevel": {
+        "enum": [
+          "Undefined",
+          "Authentication",
+          "AuthenticationAndPrivacy"
+        ],
+        "type": "string"
+      },
+      "SecurityLevelOptions": {
+        "enum": [
+          "Undefined",
+          "Authentication",
+          "AuthenticationAndPrivacy"
+        ],
+        "type": "string"
+      },
+      "SetCustomValueRequest": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SnmpDeviceDto": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "DeviceID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "DeviceGuid": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "CustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "FolderID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "Hostname": {
+            "type": "string",
+            "nullable": true
+          },
+          "Online": {
+            "type": "boolean"
+          },
+          "Port": {
+            "type": "string",
+            "nullable": true
+          },
+          "Community": {
+            "type": "string",
+            "nullable": true
+          },
+          "Type": {
+            "type": "string",
+            "nullable": true
+          },
+          "Version": {
+            "type": "string",
+            "nullable": true
+          },
+          "SecurityLevel": {
+            "$ref": "#/components/schemas/SecurityLevelOptions"
+          },
+          "Authentication": {
+            "type": "string",
+            "nullable": true
+          },
+          "Privacy": {
+            "type": "string",
+            "nullable": true
+          },
+          "Monitored": {
+            "type": "boolean"
+          },
+          "MonitoringAgentID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Model": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SnmpDeviceDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SnmpDeviceDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SnmpVersionOptions": {
+        "enum": [
+          "V1",
+          "V2"
+        ],
+        "type": "string"
+      },
+      "TcpDeviceDto": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "DeviceID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "DeviceGuid": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "Hostname": {
+            "type": "string",
+            "nullable": true
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "CustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "FolderID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "MonitoringAgentID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Monitored": {
+            "type": "boolean"
+          },
+          "Ports": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PortDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TcpDeviceDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TcpDeviceDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TechnicianCommentDetails": {
+        "type": "object",
+        "properties": {
+          "TechnicianId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "IsInternal": {
+            "type": "boolean"
+          },
+          "TechnicianEmail": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TicketCommentDto": {
+        "type": "object",
+        "properties": {
+          "Date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "Comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "CommentHtml": {
+            "type": "string",
+            "nullable": true
+          },
+          "EndUserID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "TechnicianContactID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "Email": {
+            "type": "string",
+            "nullable": true
+          },
+          "FirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "LastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "IsInternal": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TicketCommentDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TicketCommentDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TicketDto": {
+        "type": "object",
+        "properties": {
+          "TicketID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "TicketTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "TicketNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "TicketPriority": {
+            "$ref": "#/components/schemas/TicketPriorityOptions"
+          },
+          "TicketImpact": {
+            "$ref": "#/components/schemas/TicketsImpactOptions"
+          },
+          "TicketStatus": {
+            "type": "string",
+            "nullable": true
+          },
+          "TicketSource": {
+            "type": "string",
+            "nullable": true
+          },
+          "TicketType": {
+            "$ref": "#/components/schemas/TicketTypesForAPI"
+          },
+          "EndUserID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "EndUserEmail": {
+            "type": "string",
+            "nullable": true
+          },
+          "EndUserFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "EndUserLastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "EndUserPhone": {
+            "type": "string",
+            "nullable": true
+          },
+          "TicketResolvedDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "TicketCreatedDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "TechnicianFirstCommentDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "FirstResponseDueDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "ClosedTicketDueDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "FirstComment": {
+            "type": "string",
+            "nullable": true
+          },
+          "LastEndUserComment": {
+            "type": "string",
+            "nullable": true
+          },
+          "LastEndUserCommentTimestamp": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "LastTechnicianComment": {
+            "type": "string",
+            "nullable": true
+          },
+          "LastTechnicianCommentTimestamp": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "OnSiteDurationSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "deprecated": true
+          },
+          "OnSiteDurationMinutes": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "readOnly": true,
+            "deprecated": true
+          },
+          "OffSiteDurationSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "deprecated": true
+          },
+          "OffSiteDurationMinutes": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "readOnly": true,
+            "deprecated": true
+          },
+          "OnSLADurationSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "deprecated": true
+          },
+          "OnSLADurationMinutes": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "readOnly": true,
+            "deprecated": true
+          },
+          "OffSLADurationSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "deprecated": true
+          },
+          "OffSLADurationMinutes": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "readOnly": true,
+            "deprecated": true
+          },
+          "TotalDurationSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "deprecated": true
+          },
+          "TotalDurationMinutes": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "readOnly": true,
+            "deprecated": true
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "CustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "CustomerBusinessNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "TechnicianContactID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "TechnicianFullName": {
+            "type": "string",
+            "nullable": true
+          },
+          "TechnicianEmail": {
+            "type": "string",
+            "nullable": true
+          },
+          "ContractID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "RelationType": {
+            "$ref": "#/components/schemas/RelationType"
+          },
+          "RelatedTicketId": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TicketDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TicketDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TicketDurationsDto": {
+        "type": "object",
+        "properties": {
+          "OffSLADurationHours": {
+            "type": "number",
+            "format": "double"
+          },
+          "OffSiteDurationHours": {
+            "type": "number",
+            "format": "double"
+          },
+          "OnSLADurationHours": {
+            "type": "number",
+            "format": "double"
+          },
+          "OnSiteDurationHours": {
+            "type": "number",
+            "format": "double"
+          },
+          "TotalDurationHours": {
+            "type": "number",
+            "format": "double"
+          },
+          "ticketId": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TicketPriorityOptions": {
+        "enum": [
+          "Low",
+          "Medium",
+          "High",
+          "Critical"
+        ],
+        "type": "string"
+      },
+      "TicketTypesForAPI": {
+        "enum": [
+          "Incident",
+          "Problem",
+          "Request",
+          "Change"
+        ],
+        "type": "string"
+      },
+      "TicketWorkHoursDto": {
+        "type": "object",
+        "properties": {
+          "TicketID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "WorkHoursID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "StartWorkHour": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "EndWorkHour": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "TechnicianContactID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "Billiable": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "OnCustomerSite": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "Description": {
+            "type": "string",
+            "nullable": true
+          },
+          "TechnicianFullName": {
+            "type": "string",
+            "nullable": true
+          },
+          "TechnicianEmail": {
+            "type": "string",
+            "nullable": true
+          },
+          "RateID": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "RateAmount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TicketWorkHoursDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TicketWorkHoursDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TicketWorkHoursSiteDurationSummaryDto": {
+        "type": "object",
+        "properties": {
+          "TicketID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "TotalDurationSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "OnSiteDurationSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "OffSiteDurationSeconds": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TicketWorkHoursSummaryDto": {
+        "type": "object",
+        "properties": {
+          "TicketID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Billable": {
+            "$ref": "#/components/schemas/TicketDurationsDto"
+          },
+          "NonBillable": {
+            "$ref": "#/components/schemas/TicketDurationsDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TicketsImpactOptions": {
+        "enum": [
+          "NoImpact",
+          "SiteDown",
+          "ServerIssue",
+          "Minor",
+          "Major",
+          "Crisis"
+        ],
+        "type": "string"
+      },
+      "TicketsWorkHoursSiteDurationSummaryDto": {
+        "type": "object",
+        "properties": {
+          "TicketsWorkHoursSiteDurationSummaries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TicketWorkHoursSiteDurationSummaryDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateBlockHoursContractDto": {
+        "type": "object",
+        "properties": {
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          },
+          "HoursIncluded": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "CommitRollover": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateBlockMoneyContractDto": {
+        "type": "object",
+        "properties": {
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          },
+          "CommitRollover": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateContactRequest": {
+        "type": "object",
+        "properties": {
+          "Firstname": {
+            "type": "string",
+            "nullable": true
+          },
+          "Lastname": {
+            "type": "string",
+            "nullable": true
+          },
+          "JobTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "Phone": {
+            "type": "string",
+            "nullable": true
+          },
+          "MobilePhone": {
+            "type": "string",
+            "nullable": true
+          },
+          "IsContactPerson": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "InIgnoreMode": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "Archived": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "CustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "DepartmentID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "DepartmentName": {
+            "type": "string",
+            "nullable": true
+          },
+          "DefaultAgentId": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateContractDto": {
+        "type": "object",
+        "properties": {
+          "ContractName": {
+            "type": "string",
+            "nullable": true
+          },
+          "Default": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "StartDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "EndDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "Active": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "Taxable": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "TaxId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "Notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "RetainerFlatFeeContract": {
+            "$ref": "#/components/schemas/UpdateRetainerFlatFeeContractDto"
+          },
+          "HourlyContract": {
+            "$ref": "#/components/schemas/UpdateHourlyContractDto"
+          },
+          "BlockHoursContract": {
+            "$ref": "#/components/schemas/UpdateBlockHoursContractDto"
+          },
+          "BlockMoneyContract": {
+            "$ref": "#/components/schemas/UpdateBlockMoneyContractDto"
+          },
+          "RemoteMonitoringContract": {
+            "$ref": "#/components/schemas/UpdateRemoteMonitoringContractDto"
+          },
+          "OnlineBackupContract": {
+            "$ref": "#/components/schemas/UpdateOnlineBackupContractDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateCustomerRequest": {
+        "type": "object",
+        "properties": {
+          "CustomerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "BusinessNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "Domain": {
+            "type": "string",
+            "nullable": true
+          },
+          "Address": {
+            "type": "string",
+            "nullable": true
+          },
+          "City": {
+            "type": "string",
+            "nullable": true
+          },
+          "State": {
+            "type": "string",
+            "nullable": true
+          },
+          "Country": {
+            "type": "string",
+            "nullable": true
+          },
+          "Phone": {
+            "type": "string",
+            "nullable": true
+          },
+          "Fax": {
+            "type": "string",
+            "nullable": true
+          },
+          "Notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "Links": {
+            "type": "string",
+            "nullable": true
+          },
+          "Longitude": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "Latitude": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "ZipCodeStr": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateDepartmentRequest": {
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string",
+            "nullable": true
+          },
+          "Description": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateHourlyContractDto": {
+        "type": "object",
+        "properties": {
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateOnlineBackupContractDto": {
+        "type": "object",
+        "properties": {
+          "CountBy": {
+            "$ref": "#/components/schemas/ContractMonitoredByOptions"
+          },
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateRateRequest": {
+        "type": "object",
+        "properties": {
+          "Description": {
+            "type": "string",
+            "nullable": true
+          },
+          "Amount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "SKU": {
+            "type": "string",
+            "nullable": true
+          },
+          "Archived": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "Category": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateRemoteMonitoringContractDto": {
+        "type": "object",
+        "properties": {
+          "CountBy": {
+            "$ref": "#/components/schemas/ContractMonitoredByOptions"
+          },
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateRetainerFlatFeeContractDto": {
+        "type": "object",
+        "properties": {
+          "Quantity": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "BillingPeriod": {
+            "$ref": "#/components/schemas/ContractBillingPeriodOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateTicketModel": {
+        "type": "object",
+        "properties": {
+          "TicketTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "TicketStatus": {
+            "type": "string",
+            "nullable": true
+          },
+          "TicketType": {
+            "$ref": "#/components/schemas/TicketTypesForAPI"
+          },
+          "TicketPriority": {
+            "$ref": "#/components/schemas/TicketPriorityOptions"
+          },
+          "TicketImpact": {
+            "$ref": "#/components/schemas/TicketsImpactOptions"
+          },
+          "TechnicianContactID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "TechnicianEmail": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "WorkhourRecordDto": {
+        "type": "object",
+        "properties": {
+          "WorkHoursID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "TicketID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "CustomerID": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "EndUserID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "StartWorkHour": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "EndWorkHour": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "TechnicianContactID": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "Billiable": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "OnCustomerSite": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "Description": {
+            "type": "string",
+            "nullable": true
+          },
+          "TechnicianFullName": {
+            "type": "string",
+            "nullable": true
+          },
+          "TechnicianEmail": {
+            "type": "string",
+            "nullable": true
+          },
+          "RateID": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "RateAmount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "WorkhourRecordDtoPagedResult": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkhourRecordDto"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "itemsInPage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalItemCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "prevLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "nextLink": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "securitySchemes": {
+      "Bearer": {
+        "type": "http",
+        "description": "JWT Authorization header using the Bearer scheme. Example: \"Authorization: Bearer {token}\"",
+        "scheme": "Bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  },
+  "security": [
+    {
+      "Bearer": [ ]
+    }
+  ],
+  "tags": [
+    {
+      "name": "Account"
+    },
+    {
+      "name": "Agent"
+    },
+    {
+      "name": "Alert"
+    },
+    {
+      "name": "Billing"
+    },
+    {
+      "name": "Contact"
+    },
+    {
+      "name": "Contract"
+    },
+    {
+      "name": "Customer"
+    },
+    {
+      "name": "CustomValues"
+    },
+    {
+      "name": "Department"
+    },
+    {
+      "name": "Device"
+    },
+    {
+      "name": "KnowledgeBase"
+    },
+    {
+      "name": "Rate"
+    },
+    {
+      "name": "Ticket"
+    },
+    {
+      "name": "Workhour"
+    }
+  ]
+}


### PR DESCRIPTION
### Added
- API authentication now supports Atera JWT Bearer tokens in addition to legacy `X-API-KEY` headers. The module detects the format automatically by token length (short keys use `X-API-KEY`, keys longer than 100 characters use `Authorization: Bearer {token}`). Existing scripts using `Set-AteraAPIKey` or `ATERAAPIKEY` require no code changes.
- New generic request helper `New-AteraDeleteRequest` for DELETE operations against the API.
- `Get-AteraAccount` — account information (`GET /account`).
- `Get-AteraWorkHours` — workhour records with optional date and rate filters.
- **Departments:** `Get-AteraDepartments`, `Get-AteraDepartment`, `New-AteraDepartment`, `Set-AteraDepartment`, `Remove-AteraDepartment`.
- **Devices:** Generic, TCP, HTTP, and SNMP device cmdlets including list, get, create, and delete operations; `Get-AteraSnmpDeviceByGuid`, `New-AteraSnmpDeviceV1V2`, `New-AteraSnmpDeviceV3`.
- **Tickets:** `Get-AteraTicketsWithoutComments`, `Get-AteraTicketsByStatusModified`, `Get-AteraTicketsByLastModified`, `Get-AteraTicketAttachments`, `New-AteraTicketWorkHours`, `Add-AteraTicketRelation`, `Remove-AteraTicketRelation`, `Remove-AteraTicket`.
- **Customers:** `Set-AteraCustomer`, `Remove-AteraCustomer`, `New-AteraCustomerFolder`, `New-AteraCustomerAttachment`.
- **Contacts:** `Set-AteraContact`, `Remove-AteraContact`.
- **Contracts:** `New-AteraContract`, `Set-AteraContract`.
- **Rates:** `Set-AteraProduct`, `Remove-AteraProduct`, `Set-AteraExpense`, `Remove-AteraExpense`.
- **Agents:** `Get-AteraAgentInstalledPatches`, `Get-AteraAgentAvailablePatches`, `Remove-AteraAgent`.
- **Alerts:** `Remove-AteraAlert`.
- **Custom values:** `Get-AteraCustomValuesForObject`, `New-AteraCustomValue`, `Get-AteraCustomValueById`.

### Fixed
- `Set-AteraTicket`: `-TicketTitle` was ignored due to a typo in the parameter check (`$TickeTitle`).

### Changed
- Module exports now include `Remove-Atera*` and `Add-Atera*` cmdlets in addition to existing `Get-Atera*`, `Set-Atera*`, and `New-Atera*` patterns.
- `New-AteraPutRequest` and `New-AteraDeleteRequest` are included in the published function list.

### Notes
- Legacy API keys remain supported during Atera's transition period. Replace your key with a JWT from the Atera admin portal before legacy keys expire.
- Do not prefix the token with `Bearer ` in `ATERAAPIKEY` or `Set-AteraAPIKey`; the module adds the scheme automatically for JWT tokens.
